### PR TITLE
Fix crossover bug

### DIFF
--- a/plugins/sellSideStrategy.go
+++ b/plugins/sellSideStrategy.go
@@ -405,6 +405,12 @@ func (s *sellSideStrategy) modifySellLevel(offers []horizon.Offer, index int, ta
 
 	targetPrice = *model.NumberByCappingPrecision(&targetPrice, utils.SdexPrecision)
 	targetAmount = *model.NumberByCappingPrecision(&targetAmount, utils.SdexPrecision)
+
+	//changes the price back to the last price if only amountTrigger was triggered
+	if !priceTrigger {
+		targetPrice = *model.NumberFromFloat(curPrice, utils.SdexPrecision)
+	}
+
 	hitCapacityLimit, op, e := s.placeOrderWithRetry(
 		targetPrice.AsFloat(),
 		targetAmount.AsFloat(),


### PR DESCRIPTION
This should address https://github.com/lightyeario/kelp/issues/4 using the proposed fix of resetting the price if the price trigger didn't fire. I didn't live-replicate the bug because I don't have enough tokens to reliably get a partially filled level :-)