### PR TITLE
fix travis build: update travis to launch ccxt in a docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,16 @@ language: go
 
 go_import_path: github.com/stellar/kelp
 
+services:
+- docker
+
 go:
 - "1.10.x"
 - "1.11"
 
 before_install:
 - curl https://glide.sh/get | sh
+- docker run -p 3000:3000 -d franzsee/ccxt-rest
 
 install:
 - glide install


### PR DESCRIPTION
needed since we have expanded CCXT integrations using the list of exchanges returned from the CCXT endpoint