### PR TITLE
Enable additional ccxt params and http headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor/
 build/
 bin/
 .idea
+kelp.prefs

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ services:
 
 go:
 - "1.10.x"
-- "1.11"
+- "1.11.x"
+- "1.12.x"
 
 before_install:
 - curl https://glide.sh/get | sh

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The `trade` command has three required parameters which are:
 - **strategy**: the strategy you want to run (_sell_, _buysell_, _balanced_, _mirror_, _delete_).
 - **stratConf**: full path to the _.cfg_ file specific to your chosen strategy, [sample files here](examples/configs/trader/).
 
-Kelp sets the `X-App-Name` and `X-App-Version` headers on requests made to Horizon. These can be turned off using the `--no-headers` flag. See `kelp trade --help` for more information.
+Kelp sets the `X-App-Name` and `X-App-Version` headers on requests made to Horizon. These headers help us track overall Kelp usage, so that we can learn about general usage patterns and adapt Kelp to be more useful in the future. These can be turned off using the `--no-headers` flag. See `kelp trade --help` for more information.
 
 Here's an example of how to start the trading bot with the _buysell_ strategy:
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ The `trade` command has three required parameters which are:
 - **strategy**: the strategy you want to run (_sell_, _buysell_, _balanced_, _mirror_, _delete_).
 - **stratConf**: full path to the _.cfg_ file specific to your chosen strategy, [sample files here](examples/configs/trader/).
 
+Kelp sets the `X-App-Name` and `X-App-Version` headers on requests made to Horizon. These can be turned off using the `--no-headers` flag. See `kelp trade --help` for more information.
+
 Here's an example of how to start the trading bot with the _buysell_ strategy:
 
 `kelp trade --botConf ./path/trader.cfg --strategy buysell --stratConf ./path/buysell.cfg`

--- a/api/exchange.go
+++ b/api/exchange.go
@@ -73,6 +73,8 @@ type FillTrackable interface {
 type Constrainable interface {
 	// return nil if the constraint does not exist for the exchange
 	GetOrderConstraints(pair *model.TradingPair) *model.OrderConstraints
+
+	OverrideOrderConstraints(pair *model.TradingPair, override *model.OrderConstraintsOverride)
 }
 
 // OrderbookFetcher extracts out the method that should go into ExchangeShim for now

--- a/api/exchange.go
+++ b/api/exchange.go
@@ -16,8 +16,8 @@ type ExchangeAPIKey struct {
 
 // ExchangeParam specifies an additional parameter to be sent when initializing the exchange
 type ExchangeParam struct {
-	Parameter string
-	Value     string
+	Param string
+	Value string
 }
 
 // ExchangeHeader specifies additional HTTP headers

--- a/api/exchange.go
+++ b/api/exchange.go
@@ -14,6 +14,18 @@ type ExchangeAPIKey struct {
 	Secret string
 }
 
+// ExchangeParam specifies an additional parameter to be sent when initializing the exchange
+type ExchangeParam struct {
+	Parameter string
+	Value     string
+}
+
+// ExchangeHeader specifies additional HTTP headers
+type ExchangeHeader struct {
+	Header string
+	Value  string
+}
+
 // Account allows you to access key account functions
 type Account interface {
 	GetAccountBalances(assetList []interface{}) (map[interface{}]model.Number, error)

--- a/cmd/terminate.go
+++ b/cmd/terminate.go
@@ -38,8 +38,10 @@ func init() {
 
 		// --- start initialization of objects ----
 		client := &horizon.Client{
-			URL:  configFile.HorizonURL,
-			HTTP: http.DefaultClient,
+			URL:        configFile.HorizonURL,
+			HTTP:       http.DefaultClient,
+			AppName:    "kelp",
+			AppVersion: version,
 		}
 		sdex := plugins.MakeSDEX(
 			client,

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -351,7 +351,7 @@ func runTradeCmd(options inputs) {
 
 		p := prefs.Make(prefsFilename)
 		if p.FirstTime() {
-			log.Printf("Kelp sets the 'X-App-Name' and 'X-App-Version' headers on requests made to Horizon. These can be turned off using the --no-headers flag. See `kelp trade --help` for more information.\n")
+			log.Printf("Kelp sets the `X-App-Name` and `X-App-Version` headers on requests made to Horizon. These headers help us track overall Kelp usage, so that we can learn about general usage patterns and adapt Kelp to be more useful in the future. These can be turned off using the `--no-headers` flag. See `kelp trade --help` for more information.\n")
 			e := p.SetNotFirstTime()
 			if e != nil {
 				l.Info("")

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -208,8 +208,8 @@ func makeExchangeShimSdex(
 		exchangeParams := []api.ExchangeParam{}
 		for _, param := range botConfig.ExchangeParams {
 			exchangeParams = append(exchangeParams, api.ExchangeParam{
-				Parameter: param.Parameter,
-				Value:     param.Value,
+				Param: param.Param,
+				Value: param.Value,
 			})
 		}
 

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -205,8 +205,24 @@ func makeExchangeShimSdex(
 			})
 		}
 
+		exchangeParams := []api.ExchangeParam{}
+		for _, param := range botConfig.ExchangeParams {
+			exchangeParams = append(exchangeParams, api.ExchangeParam{
+				Parameter: param.Parameter,
+				Value:     param.Value,
+			})
+		}
+
+		exchangeHeaders := []api.ExchangeHeader{}
+		for _, header := range botConfig.ExchangeHeaders {
+			exchangeHeaders = append(exchangeHeaders, api.ExchangeHeader{
+				Header: header.Header,
+				Value:  header.Value,
+			})
+		}
+
 		var exchangeAPI api.Exchange
-		exchangeAPI, e = plugins.MakeTradingExchange(botConfig.TradingExchange, exchangeAPIKeys, *options.simMode)
+		exchangeAPI, e = plugins.MakeTradingExchange(botConfig.TradingExchange, exchangeAPIKeys, exchangeParams, exchangeHeaders, *options.simMode)
 		if e != nil {
 			logger.Fatal(l, fmt.Errorf("unable to make trading exchange: %s", e))
 			return nil, nil

--- a/examples/configs/trader/sample_mirror.cfg
+++ b/examples/configs/trader/sample_mirror.cfg
@@ -36,10 +36,16 @@ VOLUME_DIVIDE_BY=500.0
 # in this example the spread is 0.5%
 PER_LEVEL_SPREAD=0.005
 
-# minimum volume of base units needed to place an order on the backing exchange
 # minimum values for Kraken: https://support.kraken.com/hc/en-us/articles/205893708-What-is-the-minimum-order-size-volume-
 # minimum order value for Binance: https://support.binance.com/hc/en-us/articles/115000594711-Trading-Rule
-MIN_BASE_VOLUME=30.0
+# (optional) number of decimal units to be used for price, which is specified in units of the quote asset, needed to place an order on the backing exchange
+#PRICE_PRECISION_OVERRIDE=6
+# (optional) number of decimal units to be used for volume, which is specified in units of the base asset, needed to place an order on the backing exchange
+#VOLUME_PRECISION_OVERRIDE=1
+# (optional) minimum volume of base units needed to place an order on the backing exchange
+#MIN_BASE_VOLUME_OVERRIDE=30.0
+# (optional) minimum volume of quote units needed to place an order on the backing exchange
+#MIN_QUOTE_VOLUME_OVERRIDE=30.0
 
 # set to true if you want the bot to offset your trades onto the backing exchange to realize the per_level_spread against each trade
 # requires you to specify the EXCHANGE_API_KEYS below

--- a/examples/configs/trader/sample_mirror.cfg
+++ b/examples/configs/trader/sample_mirror.cfg
@@ -54,3 +54,13 @@ PER_LEVEL_SPREAD=0.005
 #[[EXCHANGE_API_KEYS]]
 #KEY=""
 #SECRET=""
+
+# if your exchange requires additional parameters, list them here with the the necessary values (only ccxt supported currently)
+# [[EXCHANGE_PARAMS]]
+# PARAMETER=""
+# VALUE=""
+
+# if your exchange requires additional headers, list them here with the the necessary values (only ccxt supported currently)
+# [[EXCHANGE_HEADERS]]
+# HEADER=""
+# VALUE=""

--- a/examples/configs/trader/sample_mirror.cfg
+++ b/examples/configs/trader/sample_mirror.cfg
@@ -56,11 +56,11 @@ PER_LEVEL_SPREAD=0.005
 #SECRET=""
 
 # if your exchange requires additional parameters, list them here with the the necessary values (only ccxt supported currently)
-# [[EXCHANGE_PARAMS]]
-# PARAMETER=""
-# VALUE=""
+#[[EXCHANGE_PARAMS]]
+#PARAM=""
+#VALUE=""
 
 # if your exchange requires additional headers, list them here with the the necessary values (only ccxt supported currently)
-# [[EXCHANGE_HEADERS]]
-# HEADER=""
-# VALUE=""
+#[[EXCHANGE_HEADERS]]
+#HEADER=""
+#VALUE=""

--- a/examples/configs/trader/sample_trader.cfg
+++ b/examples/configs/trader/sample_trader.cfg
@@ -85,10 +85,17 @@ MAX_OP_FEE_STROOPS=5000
 # Google authentication.
 #ACCEPTABLE_GOOGLE_EMAILS=""
 
-# minimum volume of base units needed to place an order on the non-sdex (centralized) exchange
 # minimum values for Kraken: https://support.kraken.com/hc/en-us/articles/205893708-What-is-the-minimum-order-size-volume-
 # minimum order value for Binance: https://support.binance.com/hc/en-us/articles/115000594711-Trading-Rule
-#MIN_CENTRALIZED_BASE_VOLUME=30.0
+# (optional) number of decimal units to be used for price, which is specified in units of the quote asset, to place an order on the non-sdex (centralized) exchange
+#CENTRALIZED_PRICE_PRECISION_OVERRIDE=6
+# (optional) number of decimal units to be used for volume, which is specified in units of the base asset, to place an order on the non-sdex (centralized) exchange
+#CENTRALIZED_VOLUME_PRECISION_OVERRIDE=1
+# (optional) minimum volume of base units needed to place an order on the non-sdex (centralized) exchange
+#CENTRALIZED_MIN_BASE_VOLUME_OVERRIDE=30.0
+# (optional) minimum volume of quote units needed to place an order on the non-sdex (centralized) exchange
+#CENTRALIZED_MIN_QUOTE_VOLUME_OVERRIDE=10.0
+
 # uncomment lines below to use kraken. Can use "sdex" or leave out to trade on the Stellar Decentralized Exchange.
 # can alternatively use any of the ccxt-exchanges marked as "Trading" (run `kelp exchanges` for full list)
 #TRADING_EXCHANGE="kraken"

--- a/examples/configs/trader/sample_trader.cfg
+++ b/examples/configs/trader/sample_trader.cfg
@@ -106,3 +106,20 @@ MAX_OP_FEE_STROOPS=5000
 #[[EXCHANGE_API_KEYS]]
 #KEY=""
 #SECRET=""
+
+# if your exchange requires additional parameters during initialization, list them here (only ccxt supported currently)
+# Note that some CCXT exchanges require additional parameters, e.g. coinbase pro requires a "password"
+#[[EXCHANGE_PARAMS]]
+#PARAMETER=""
+#VALUE=""
+#[[EXCHANGE_PARAMS]]
+#PARAMETER=""
+#VALUE=""
+
+# if your exchange requires additional parameters as http headers, list them here (only ccxt supported currently)
+#[[EXCHANGE_HEADERS]]
+#HEADER=""
+#VALUE=""
+#[[EXCHANGE_HEADERS]]
+#HEADER=""
+#VALUE=""

--- a/examples/configs/trader/sample_trader.cfg
+++ b/examples/configs/trader/sample_trader.cfg
@@ -110,10 +110,10 @@ MAX_OP_FEE_STROOPS=5000
 # if your exchange requires additional parameters during initialization, list them here (only ccxt supported currently)
 # Note that some CCXT exchanges require additional parameters, e.g. coinbase pro requires a "password"
 #[[EXCHANGE_PARAMS]]
-#PARAMETER=""
+#PARAM=""
 #VALUE=""
 #[[EXCHANGE_PARAMS]]
-#PARAMETER=""
+#PARAM=""
 #VALUE=""
 
 # if your exchange requires additional parameters as http headers, list them here (only ccxt supported currently)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0ab15bf176f8313235c90ce78694e51ca8da996fd0c80187810a19536864ca1b
-updated: 2019-03-26T14:36:41.239077092-07:00
+hash: c1a6fe42c2e0796f29822018134adc2401292b654fec58b7d790daafceec2585
+updated: 2019-04-03T12:27:32.117314051-07:00
 imports:
 - name: cloud.google.com/go
   version: 793297ec250352b0ece46e103381a0fc3dab95a1
@@ -74,7 +74,7 @@ imports:
 - name: github.com/spf13/viper
   version: db7ff930a189b98d602179d9001d33345f42b8c7
 - name: github.com/stellar/go
-  version: 61ed9984b1f88fda0d4e5e375021b404d9900959
+  version: a45d1ae036357adf337060c7b15dbe9abc235025
   subpackages:
   - amount
   - build
@@ -88,6 +88,7 @@ imports:
   - protocols/horizon
   - protocols/horizon/base
   - protocols/horizon/effects
+  - protocols/horizon/operations
   - strkey
   - support/app
   - support/config

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,10 +9,11 @@ import:
 - package: github.com/spf13/pflag
   version: v1.0.0
 - package: github.com/stellar/go
-  version: 61ed9984b1f88fda0d4e5e375021b404d9900959
+  version: a45d1ae036357adf337060c7b15dbe9abc235025
   subpackages:
   - build
   - clients/horizon
+  - exp/clients/horizon
   - support/config
   - support/errors
 ##############################################################

--- a/model/orderbook.go
+++ b/model/orderbook.go
@@ -305,6 +305,28 @@ func MakeOrderConstraintsWithCost(pricePrecision int8, volumePrecision int8, min
 	}
 }
 
+// MakeOrderConstraintsWithOverride is a factory method for OrderConstraints, oc is not a pointer because we want a copy since we modify it
+func MakeOrderConstraintsWithOverride(oc OrderConstraints, override *OrderConstraintsOverride) *OrderConstraints {
+	if override.PricePrecision != nil {
+		oc.PricePrecision = *override.PricePrecision
+	}
+	if override.VolumePrecision != nil {
+		oc.VolumePrecision = *override.VolumePrecision
+	}
+	if override.MinBaseVolume != nil {
+		oc.MinBaseVolume = *override.MinBaseVolume
+	}
+	if override.MinQuoteVolume != nil {
+		oc.MinQuoteVolume = *override.MinQuoteVolume
+	}
+	return &oc
+}
+
+// MakeOrderConstraintsFromOverride is a factory method to convert an OrderConstraintsOverride to an OrderConstraints
+func MakeOrderConstraintsFromOverride(override *OrderConstraintsOverride) *OrderConstraints {
+	return MakeOrderConstraintsWithOverride(OrderConstraints{}, override)
+}
+
 // OrderConstraints describes constraints when placing orders on an excahnge
 func (o *OrderConstraints) String() string {
 	minQuoteVolumeStr := nilString
@@ -314,4 +336,77 @@ func (o *OrderConstraints) String() string {
 
 	return fmt.Sprintf("OrderConstraints[PricePrecision: %d, VolumePrecision: %d, MinBaseVolume: %s, MinQuoteVolume: %s]",
 		o.PricePrecision, o.VolumePrecision, o.MinBaseVolume.AsString(), minQuoteVolumeStr)
+}
+
+// OrderConstraintsOverride describes an override for an OrderConstraint
+type OrderConstraintsOverride struct {
+	PricePrecision  *int8
+	VolumePrecision *int8
+	MinBaseVolume   *Number
+	MinQuoteVolume  **Number
+}
+
+// MakeOrderConstraintsOverride is a factory method
+func MakeOrderConstraintsOverride(
+	pricePrecision *int8,
+	volumePrecision *int8,
+	minBaseVolume *Number,
+	minQuoteVolume **Number,
+) *OrderConstraintsOverride {
+	return &OrderConstraintsOverride{
+		PricePrecision:  pricePrecision,
+		VolumePrecision: volumePrecision,
+		MinBaseVolume:   minBaseVolume,
+		MinQuoteVolume:  minQuoteVolume,
+	}
+}
+
+// MakeOrderConstraintsOverrideFromConstraints is a factory method for OrderConstraintsOverride
+func MakeOrderConstraintsOverrideFromConstraints(oc *OrderConstraints) *OrderConstraintsOverride {
+	return &OrderConstraintsOverride{
+		PricePrecision:  &oc.PricePrecision,
+		VolumePrecision: &oc.VolumePrecision,
+		MinBaseVolume:   &oc.MinBaseVolume,
+		MinQuoteVolume:  &oc.MinQuoteVolume,
+	}
+}
+
+// IsComplete returns true if the override contains all values
+func (override *OrderConstraintsOverride) IsComplete() bool {
+	if override.PricePrecision == nil {
+		return false
+	}
+
+	if override.VolumePrecision == nil {
+		return false
+	}
+
+	if override.MinBaseVolume == nil {
+		return false
+	}
+
+	if override.MinQuoteVolume == nil {
+		return false
+	}
+
+	return true
+}
+
+// Augment only updates values if updates are non-nil
+func (override *OrderConstraintsOverride) Augment(updates *OrderConstraintsOverride) {
+	if updates.PricePrecision != nil {
+		override.PricePrecision = updates.PricePrecision
+	}
+
+	if updates.VolumePrecision != nil {
+		override.VolumePrecision = updates.VolumePrecision
+	}
+
+	if updates.MinBaseVolume != nil {
+		override.MinBaseVolume = updates.MinBaseVolume
+	}
+
+	if updates.MinQuoteVolume != nil {
+		override.MinQuoteVolume = updates.MinQuoteVolume
+	}
 }

--- a/model/tradingPair.go
+++ b/model/tradingPair.go
@@ -48,14 +48,35 @@ func (p TradingPair) ToString(c *AssetConverter, delim string) (string, error) {
 
 // TradingPairFromString makes a TradingPair out of a string
 func TradingPairFromString(codeSize int8, c *AssetConverter, p string) (*TradingPair, error) {
-	base, e := c.FromString(p[0:codeSize])
+	return TradingPairFromString2(codeSize, []*AssetConverter{c}, p)
+}
+
+// TradingPairFromString2 makes a TradingPair out of a string
+func TradingPairFromString2(codeSize int8, converters []*AssetConverter, p string) (*TradingPair, error) {
+	var base Asset
+	var quote Asset
+	var e error
+
+	baseString := p[0:codeSize]
+	for _, c := range converters {
+		base, e = c.FromString(baseString)
+		if e == nil {
+			break
+		}
+	}
 	if e != nil {
-		return nil, fmt.Errorf("base asset could not be converted: %s", e)
+		return nil, fmt.Errorf("base asset could not be converted using any of the converters in the list of %d converters: %s", len(converters), baseString)
 	}
 
-	quote, e := c.FromString(p[codeSize : codeSize*2])
+	quoteString := p[codeSize : codeSize*2]
+	for _, c := range converters {
+		quote, e = c.FromString(quoteString)
+		if e == nil {
+			break
+		}
+	}
 	if e != nil {
-		return nil, fmt.Errorf("quote asset could not be converted: %s", e)
+		return nil, fmt.Errorf("quote asset could not be converted using any of the converters in the list of %d converters: %s", len(converters), quoteString)
 	}
 
 	return &TradingPair{Base: base, Quote: quote}, nil

--- a/plugins/batchedExchange.go
+++ b/plugins/batchedExchange.go
@@ -154,6 +154,11 @@ func (b BatchedExchange) GetOrderConstraints(pair *model.TradingPair) *model.Ord
 	return b.inner.GetOrderConstraints(pair)
 }
 
+// OverrideOrderConstraints impl, can partially override values for specific pairs
+func (b BatchedExchange) OverrideOrderConstraints(pair *model.TradingPair, override *model.OrderConstraintsOverride) {
+	b.inner.OverrideOrderConstraints(pair, override)
+}
+
 // GetOrderBook impl
 func (b BatchedExchange) GetOrderBook(pair *model.TradingPair, maxCount int32) (*model.OrderBook, error) {
 	return b.inner.GetOrderBook(pair, maxCount)
@@ -192,12 +197,6 @@ func (b BatchedExchange) SubmitOps(ops []build.TransactionMutator, asyncCallback
 		}
 		return nil
 	}
-
-	pair := &model.TradingPair{
-		Base:  model.FromHorizonAsset(b.baseAsset),
-		Quote: model.FromHorizonAsset(b.quoteAsset),
-	}
-	log.Printf("order constraints for trading pair %s: %s", pair, b.inner.GetOrderConstraints(pair))
 
 	results := []submitResult{}
 	numProcessed := 0

--- a/plugins/ccxtExchange.go
+++ b/plugins/ccxtExchange.go
@@ -32,6 +32,8 @@ func makeCcxtExchange(
 	exchangeName string,
 	orderConstraintOverrides map[model.TradingPair]model.OrderConstraints,
 	apiKeys []api.ExchangeAPIKey,
+	exchangeParams []api.ExchangeParam,
+	headers []api.ExchangeHeader,
 	simMode bool,
 ) (api.Exchange, error) {
 	if len(apiKeys) == 0 {
@@ -42,7 +44,7 @@ func makeCcxtExchange(
 		return nil, fmt.Errorf("need exactly 1 ExchangeAPIKey")
 	}
 
-	c, e := sdk.MakeInitializedCcxtExchange(exchangeName, apiKeys[0])
+	c, e := sdk.MakeInitializedCcxtExchange(exchangeName, apiKeys[0], exchangeParams, headers)
 	if e != nil {
 		return nil, fmt.Errorf("error making a ccxt exchange: %s", e)
 	}

--- a/plugins/ccxtExchange_test.go
+++ b/plugins/ccxtExchange_test.go
@@ -14,6 +14,7 @@ import (
 
 var supportedExchanges = []string{"binance"}
 var emptyAPIKey = api.ExchangeAPIKey{}
+var emptyParams = api.ExchangeParam{}
 var supportedTradingExchanges = map[string]api.ExchangeAPIKey{
 	"binance": {},
 }
@@ -30,7 +31,7 @@ func TestGetTickerPrice_Ccxt(t *testing.T) {
 
 	for _, exchangeName := range supportedExchanges {
 		t.Run(exchangeName, func(t *testing.T) {
-			testCcxtExchange, e := makeCcxtExchange(exchangeName, testOrderConstraints, []api.ExchangeAPIKey{emptyAPIKey}, false)
+			testCcxtExchange, e := makeCcxtExchange(exchangeName, testOrderConstraints, []api.ExchangeAPIKey{emptyAPIKey}, []api.ExchangeParam{emptyParams}, []api.ExchangeHeader{}, false)
 			if !assert.NoError(t, e) {
 				return
 			}
@@ -57,7 +58,7 @@ func TestGetOrderBook_Ccxt(t *testing.T) {
 
 	for _, exchangeName := range supportedExchanges {
 		t.Run(exchangeName, func(t *testing.T) {
-			testCcxtExchange, e := makeCcxtExchange(exchangeName, testOrderConstraints, []api.ExchangeAPIKey{emptyAPIKey}, false)
+			testCcxtExchange, e := makeCcxtExchange(exchangeName, testOrderConstraints, []api.ExchangeAPIKey{emptyAPIKey}, []api.ExchangeParam{emptyParams}, []api.ExchangeHeader{}, false)
 			if !assert.NoError(t, e) {
 				return
 			}
@@ -90,7 +91,7 @@ func TestGetTrades_Ccxt(t *testing.T) {
 
 	for _, exchangeName := range supportedExchanges {
 		t.Run(exchangeName, func(t *testing.T) {
-			testCcxtExchange, e := makeCcxtExchange(exchangeName, testOrderConstraints, []api.ExchangeAPIKey{emptyAPIKey}, false)
+			testCcxtExchange, e := makeCcxtExchange(exchangeName, testOrderConstraints, []api.ExchangeAPIKey{emptyAPIKey}, []api.ExchangeParam{}, []api.ExchangeHeader{}, false)
 			if !assert.NoError(t, e) {
 				return
 			}
@@ -115,7 +116,7 @@ func TestGetTradeHistory_Ccxt(t *testing.T) {
 
 	for exchangeName, apiKey := range supportedTradingExchanges {
 		t.Run(exchangeName, func(t *testing.T) {
-			testCcxtExchange, e := makeCcxtExchange(exchangeName, testOrderConstraints, []api.ExchangeAPIKey{apiKey}, false)
+			testCcxtExchange, e := makeCcxtExchange(exchangeName, testOrderConstraints, []api.ExchangeAPIKey{apiKey}, []api.ExchangeParam{emptyParams}, []api.ExchangeHeader{}, false)
 			if !assert.NoError(t, e) {
 				return
 			}
@@ -173,7 +174,7 @@ func validateTrades(t *testing.T, pair model.TradingPair, trades []model.Trade) 
 func TestGetLatestTradeCursor_Ccxt(t *testing.T) {
 	for exchangeName, apiKey := range supportedTradingExchanges {
 		t.Run(exchangeName, func(t *testing.T) {
-			testCcxtExchange, e := makeCcxtExchange(exchangeName, testOrderConstraints, []api.ExchangeAPIKey{apiKey}, false)
+			testCcxtExchange, e := makeCcxtExchange(exchangeName, testOrderConstraints, []api.ExchangeAPIKey{apiKey}, []api.ExchangeParam{emptyParams}, []api.ExchangeHeader{}, false)
 			if !assert.NoError(t, e) {
 				return
 			}
@@ -212,7 +213,7 @@ func TestGetAccountBalances_Ccxt(t *testing.T) {
 
 	for exchangeName, apiKey := range supportedTradingExchanges {
 		t.Run(exchangeName, func(t *testing.T) {
-			testCcxtExchange, e := makeCcxtExchange(exchangeName, testOrderConstraints, []api.ExchangeAPIKey{apiKey}, false)
+			testCcxtExchange, e := makeCcxtExchange(exchangeName, testOrderConstraints, []api.ExchangeAPIKey{apiKey}, []api.ExchangeParam{emptyParams}, []api.ExchangeHeader{}, false)
 			if !assert.NoError(t, e) {
 				return
 			}
@@ -257,7 +258,7 @@ func TestGetOpenOrders_Ccxt(t *testing.T) {
 	for exchangeName, apiKey := range supportedTradingExchanges {
 		for _, pair := range tradingPairs {
 			t.Run(exchangeName, func(t *testing.T) {
-				testCcxtExchange, e := makeCcxtExchange(exchangeName, testOrderConstraints, []api.ExchangeAPIKey{apiKey}, false)
+				testCcxtExchange, e := makeCcxtExchange(exchangeName, testOrderConstraints, []api.ExchangeAPIKey{apiKey}, []api.ExchangeParam{emptyParams}, []api.ExchangeHeader{}, false)
 				if !assert.NoError(t, e) {
 					return
 				}
@@ -372,7 +373,7 @@ func TestAddOrder_Ccxt(t *testing.T) {
 			},
 		} {
 			t.Run(exchangeName, func(t *testing.T) {
-				testCcxtExchange, e := makeCcxtExchange(exchangeName, testOrderConstraints, []api.ExchangeAPIKey{apiKey}, false)
+				testCcxtExchange, e := makeCcxtExchange(exchangeName, testOrderConstraints, []api.ExchangeAPIKey{apiKey}, []api.ExchangeParam{emptyParams}, []api.ExchangeHeader{}, false)
 				if !assert.NoError(t, e) {
 					return
 				}
@@ -422,7 +423,7 @@ func TestCancelOrder_Ccxt(t *testing.T) {
 			},
 		} {
 			t.Run(exchangeName, func(t *testing.T) {
-				testCcxtExchange, e := makeCcxtExchange(exchangeName, testOrderConstraints, []api.ExchangeAPIKey{apiKey}, false)
+				testCcxtExchange, e := makeCcxtExchange(exchangeName, testOrderConstraints, []api.ExchangeAPIKey{apiKey}, []api.ExchangeParam{emptyParams}, []api.ExchangeHeader{}, false)
 				if !assert.NoError(t, e) {
 					return
 				}
@@ -442,6 +443,7 @@ func TestCancelOrder_Ccxt(t *testing.T) {
 }
 
 func TestGetOrderConstraints_Ccxt_Precision(t *testing.T) {
+	// coinbasepro gives incorrect precision values so we do not test it here
 	testCases := []struct {
 		exchangeName       string
 		pair               *model.TradingPair
@@ -473,7 +475,7 @@ func TestGetOrderConstraints_Ccxt_Precision(t *testing.T) {
 
 	for _, kase := range testCases {
 		t.Run(kase.exchangeName, func(t *testing.T) {
-			testCcxtExchange, e := makeCcxtExchange(kase.exchangeName, nil, []api.ExchangeAPIKey{emptyAPIKey}, false)
+			testCcxtExchange, e := makeCcxtExchange(kase.exchangeName, nil, []api.ExchangeAPIKey{emptyAPIKey}, []api.ExchangeParam{emptyParams}, []api.ExchangeHeader{}, false)
 			if !assert.NoError(t, e) {
 				return
 			}

--- a/plugins/factory.go
+++ b/plugins/factory.go
@@ -151,8 +151,10 @@ func Strategies() map[string]StrategyContainer {
 
 // exchangeFactoryData is a data container that has all the information needed to make an exchange
 type exchangeFactoryData struct {
-	simMode bool
-	apiKeys []api.ExchangeAPIKey
+	simMode        bool
+	apiKeys        []api.ExchangeAPIKey
+	exchangeParams []api.ExchangeParam
+	headers        []api.ExchangeHeader
 }
 
 // ExchangeContainer contains the exchange factory method along with some metadata
@@ -214,6 +216,8 @@ func loadExchanges() {
 						boundExchangeName,
 						nil,
 						exchangeFactoryData.apiKeys,
+						exchangeFactoryData.exchangeParams,
+						exchangeFactoryData.headers,
 						exchangeFactoryData.simMode,
 					)
 				},
@@ -241,7 +245,7 @@ func MakeExchange(exchangeType string, simMode bool) (api.Exchange, error) {
 }
 
 // MakeTradingExchange is a factory method to make an exchange based on a given type
-func MakeTradingExchange(exchangeType string, apiKeys []api.ExchangeAPIKey, simMode bool) (api.Exchange, error) {
+func MakeTradingExchange(exchangeType string, apiKeys []api.ExchangeAPIKey, exchangeParams []api.ExchangeParam, headers []api.ExchangeHeader, simMode bool) (api.Exchange, error) {
 	if exchange, ok := getExchanges()[exchangeType]; ok {
 		if !exchange.TradeEnabled {
 			return nil, fmt.Errorf("trading is not enabled on this exchange: %s", exchangeType)
@@ -252,8 +256,10 @@ func MakeTradingExchange(exchangeType string, apiKeys []api.ExchangeAPIKey, simM
 		}
 
 		x, e := exchange.makeFn(exchangeFactoryData{
-			simMode: simMode,
-			apiKeys: apiKeys,
+			simMode:        simMode,
+			apiKeys:        apiKeys,
+			exchangeParams: exchangeParams,
+			headers:        headers,
 		})
 		if e != nil {
 			return nil, fmt.Errorf("error when making the '%s' exchange: %s", exchangeType, e)

--- a/plugins/ieif.go
+++ b/plugins/ieif.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/stellar/go/clients/horizon"
 	"github.com/stellar/kelp/api"
@@ -168,15 +169,16 @@ func (ieif *IEIF) LogAllLiabilities(assetBase horizon.Asset, assetQuote horizon.
 }
 
 func (ieif *IEIF) logLiabilities(asset horizon.Asset, assetStr string) {
+	trimmedAssetStr := strings.TrimSpace(assetStr)
 	l, e := ieif.assetLiabilities(asset)
 	if e != nil {
-		log.Printf("could not fetch liability for asset '%s', error = %s\n", assetStr, e)
+		log.Printf("could not fetch liability for %s asset, error = %s\n", trimmedAssetStr, e)
 		return
 	}
 
 	balance, e := ieif.assetBalance(asset)
 	if e != nil {
-		log.Printf("cannot fetch balance for asset '%s', error = %s\n", assetStr, e)
+		log.Printf("cannot fetch balance for %s asset, error = %s\n", trimmedAssetStr, e)
 		return
 	}
 	// TODO don't break out into vars

--- a/plugins/krakenExchange.go
+++ b/plugins/krakenExchange.go
@@ -220,12 +220,13 @@ func (k *krakenExchange) GetOpenOrders(pairs []*model.TradingPair) (map[model.Tr
 		return nil, e
 	}
 
+	assetConverters := []*model.AssetConverter{k.assetConverterOpenOrders, model.Display}
 	m := map[model.TradingPair][]model.OpenOrder{}
 	for ID, o := range openOrdersResponse.Open {
 		// kraken uses different symbols when fetching open orders!
-		pair, e := model.TradingPairFromString(3, k.assetConverterOpenOrders, o.Description.AssetPair)
+		pair, e := model.TradingPairFromString2(3, assetConverters, o.Description.AssetPair)
 		if e != nil {
-			return nil, e
+			return nil, fmt.Errorf("error parsing trading pair '%s' in krakenExchange#GetOpenOrders: %s", o.Description.AssetPair, e)
 		}
 
 		if _, ok := pairsMap[*pair]; !ok {
@@ -376,7 +377,7 @@ func (k *krakenExchange) getTradeHistory(tradingPair model.TradingPair, maybeCur
 		var pair *model.TradingPair
 		pair, e = model.TradingPairFromString(4, k.assetConverter, _pair)
 		if e != nil {
-			return nil, e
+			return nil, fmt.Errorf("error parsing trading pair '%s' in krakenExchange#getTradeHistory: %s", _pair, e)
 		}
 		orderConstraints := k.GetOrderConstraints(pair)
 		// for now use the max precision between price and volume for fee and cost

--- a/plugins/krakenExchange_test.go
+++ b/plugins/krakenExchange_test.go
@@ -16,11 +16,12 @@ import (
 var testKrakenExchange api.Exchange = &krakenExchange{
 	assetConverter:           model.KrakenAssetConverter,
 	assetConverterOpenOrders: model.KrakenAssetConverterOpenOrders,
-	apis:         []*krakenapi.KrakenApi{krakenapi.New("", "")},
-	apiNextIndex: 0,
-	delimiter:    "",
-	withdrawKeys: asset2Address2Key{},
-	isSimulated:  true,
+	apis:               []*krakenapi.KrakenApi{krakenapi.New("", "")},
+	apiNextIndex:       0,
+	delimiter:          "",
+	ocOverridesHandler: MakeEmptyOrderConstraintsOverridesHandler(),
+	withdrawKeys:       asset2Address2Key{},
+	isSimulated:        true,
 }
 
 func TestGetTickerPrice(t *testing.T) {

--- a/plugins/mirrorStrategy.go
+++ b/plugins/mirrorStrategy.go
@@ -374,7 +374,7 @@ func (s *mirrorStrategy) doModifyOffer(
 	// convert the precision from the backing exchange to the primary exchange
 	offerPrice := model.NumberByCappingPrecision(price, s.primaryConstraints.PricePrecision)
 	offerAmount := model.NumberByCappingPrecision(vol, s.primaryConstraints.VolumePrecision)
-	if offerAmount.AsFloat() < s.backingConstraints.MinBaseVolume.AsFloat() {
+	if s.offsetTrades && offerAmount.AsFloat() < s.backingConstraints.MinBaseVolume.AsFloat() {
 		log.Printf("deleting level, baseVolume (%f) on backing exchange dropped below minBaseVolume of backing exchange (%f)\n",
 			offerAmount.AsFloat(), s.backingConstraints.MinBaseVolume.AsFloat())
 		deleteOp := s.sdex.DeleteOffer(oldOffer)

--- a/plugins/mirrorStrategy.go
+++ b/plugins/mirrorStrategy.go
@@ -29,16 +29,16 @@ func (t *exchangeAPIKeysToml) toExchangeAPIKeys() []api.ExchangeAPIKey {
 }
 
 type exchangeParamsToml []struct {
-	Parameter string `valid:"-" toml:"PARAMETER"`
-	Value     string `valid:"-" toml:"VALUE"`
+	Param string `valid:"-" toml:"PARAM"`
+	Value string `valid:"-" toml:"VALUE"`
 }
 
 func (t *exchangeParamsToml) toExchangeParams() []api.ExchangeParam {
 	exchangeParams := []api.ExchangeParam{}
 	for _, param := range *t {
 		exchangeParams = append(exchangeParams, api.ExchangeParam{
-			Parameter: param.Parameter,
-			Value:     param.Value,
+			Param: param.Param,
+			Value: param.Value,
 		})
 	}
 	return exchangeParams

--- a/plugins/mirrorStrategy.go
+++ b/plugins/mirrorStrategy.go
@@ -28,6 +28,38 @@ func (t *exchangeAPIKeysToml) toExchangeAPIKeys() []api.ExchangeAPIKey {
 	return apiKeys
 }
 
+type exchangeParamsToml []struct {
+	Parameter string `valid:"-" toml:"PARAMETER"`
+	Value     string `valid:"-" toml:"VALUE"`
+}
+
+func (t *exchangeParamsToml) toExchangeParams() []api.ExchangeParam {
+	exchangeParams := []api.ExchangeParam{}
+	for _, param := range *t {
+		exchangeParams = append(exchangeParams, api.ExchangeParam{
+			Parameter: param.Parameter,
+			Value:     param.Value,
+		})
+	}
+	return exchangeParams
+}
+
+type exchangeHeadersToml []struct {
+	Header string `valid:"-" toml:"HEADER"`
+	Value  string `valid:"-" toml:"VALUE"`
+}
+
+func (t *exchangeHeadersToml) toExchangeHeaders() []api.ExchangeHeader {
+	apiHeaders := []api.ExchangeHeader{}
+	for _, header := range *t {
+		apiHeaders = append(apiHeaders, api.ExchangeHeader{
+			Header: header.Header,
+			Value:  header.Value,
+		})
+	}
+	return apiHeaders
+}
+
 // mirrorConfig contains the configuration params for this strategy
 type mirrorConfig struct {
 	Exchange                string              `valid:"-" toml:"EXCHANGE"`
@@ -42,12 +74,16 @@ type mirrorConfig struct {
 	MinQuoteVolumeOverride  *float64            `valid:"-" toml:"MIN_QUOTE_VOLUME_OVERRIDE"`
 	OffsetTrades            bool                `valid:"-" toml:"OFFSET_TRADES"`
 	ExchangeAPIKeys         exchangeAPIKeysToml `valid:"-" toml:"EXCHANGE_API_KEYS"`
+	ExchangeParams          exchangeParamsToml  `valid:"-" toml:"EXCHANGE_PARAMS"`
+	ExchangeHeaders         exchangeHeadersToml `valid:"-" toml:"EXCHANGE_HEADERS"`
 }
 
 // String impl.
 func (c mirrorConfig) String() string {
 	return utils.StructString(c, map[string]func(interface{}) interface{}{
 		"EXCHANGE_API_KEYS":         utils.Hide,
+		"EXCHANGE_PARAMS":           utils.Hide,
+		"EXCHANGE_HEADERS":          utils.Hide,
 		"PRICE_PRECISION_OVERRIDE":  utils.UnwrapInt8Pointer,
 		"VOLUME_PRECISION_OVERRIDE": utils.UnwrapInt8Pointer,
 		"MIN_BASE_VOLUME_OVERRIDE":  utils.UnwrapFloat64Pointer,
@@ -104,7 +140,9 @@ func makeMirrorStrategy(sdex *SDEX, ieif *IEIF, pair *model.TradingPair, baseAss
 	var e error
 	if config.OffsetTrades {
 		exchangeAPIKeys := config.ExchangeAPIKeys.toExchangeAPIKeys()
-		exchange, e = MakeTradingExchange(config.Exchange, exchangeAPIKeys, simMode)
+		exchangeParams := config.ExchangeParams.toExchangeParams()
+		exchangeHeaders := config.ExchangeHeaders.toExchangeHeaders()
+		exchange, e = MakeTradingExchange(config.Exchange, exchangeAPIKeys, exchangeParams, exchangeHeaders, simMode)
 		if e != nil {
 			return nil, e
 		}

--- a/plugins/orderConstraintsOverridesHandler.go
+++ b/plugins/orderConstraintsOverridesHandler.go
@@ -1,0 +1,62 @@
+package plugins
+
+import "github.com/stellar/kelp/model"
+
+// OrderConstraintsOverridesHandler knows how to capture overrides and apply them onto OrderConstraints
+type OrderConstraintsOverridesHandler struct {
+	overrides map[string]*model.OrderConstraintsOverride
+}
+
+// MakeEmptyOrderConstraintsOverridesHandler is a factory method
+func MakeEmptyOrderConstraintsOverridesHandler() *OrderConstraintsOverridesHandler {
+	return &OrderConstraintsOverridesHandler{
+		overrides: map[string]*model.OrderConstraintsOverride{},
+	}
+}
+
+// MakeOrderConstraintsOverridesHandler is a factory method
+func MakeOrderConstraintsOverridesHandler(inputs map[model.TradingPair]model.OrderConstraints) *OrderConstraintsOverridesHandler {
+	overrides := map[string]*model.OrderConstraintsOverride{}
+	for p, oc := range inputs {
+		overrides[p.String()] = model.MakeOrderConstraintsOverrideFromConstraints(&oc)
+	}
+
+	return &OrderConstraintsOverridesHandler{
+		overrides: overrides,
+	}
+}
+
+// Apply creates a new order constraints after checking for any existing overrides
+func (ocHandler *OrderConstraintsOverridesHandler) Apply(pair *model.TradingPair, oc *model.OrderConstraints) *model.OrderConstraints {
+	override, has := ocHandler.overrides[pair.String()]
+	if !has {
+		return oc
+	}
+	return model.MakeOrderConstraintsWithOverride(*oc, override)
+}
+
+// Get impl, panics if the override does not exist
+func (ocHandler *OrderConstraintsOverridesHandler) Get(pair *model.TradingPair) *model.OrderConstraintsOverride {
+	return ocHandler.overrides[pair.String()]
+}
+
+// Upsert allows you to set overrides to partially override values for specific pairs
+func (ocHandler *OrderConstraintsOverridesHandler) Upsert(pair *model.TradingPair, override *model.OrderConstraintsOverride) {
+	existingOverride, exists := ocHandler.overrides[pair.String()]
+	if !exists {
+		ocHandler.overrides[pair.String()] = override
+		return
+	}
+
+	existingOverride.Augment(override)
+	ocHandler.overrides[pair.String()] = existingOverride
+}
+
+// IsCompletelyOverriden returns true if the override exists and is complete for the given trading pair
+func (ocHandler *OrderConstraintsOverridesHandler) IsCompletelyOverriden(pair *model.TradingPair) bool {
+	override, has := ocHandler.overrides[pair.String()]
+	if !has {
+		return false
+	}
+	return override.IsComplete()
+}

--- a/plugins/sdexExtensions.go
+++ b/plugins/sdexExtensions.go
@@ -3,7 +3,6 @@ package plugins
 import (
 	"fmt"
 	"log"
-	"net/http"
 
 	"github.com/stellar/go/exp/clients/horizon"
 	hProtocol "github.com/stellar/go/protocols/horizon"
@@ -25,10 +24,10 @@ var validPercentiles = []uint8{10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 99}
 
 // SdexFeeFnFromStats returns an OpFeeStroops that uses the /fee_stats endpoint
 func SdexFeeFnFromStats(
-	horizonBaseURL string,
 	capacityTrigger float64,
 	percentile uint8,
 	maxOpFeeStroops uint64,
+	newClient *horizonclient.Client,
 ) (OpFeeStroops, error) {
 	isValid := false
 	for _, p := range validPercentiles {
@@ -49,14 +48,8 @@ func SdexFeeFnFromStats(
 		return nil, fmt.Errorf("unable to create SdexFeeFnFromStats, maxOpFeeStroops should be >= %d (baseFeeStroops): %d", baseFeeStroops, maxOpFeeStroops)
 	}
 
-	client := &horizonclient.Client{
-		// TODO horizonclient.Client has a bug in it where it does not use "/" to separate the horizonURL from the fee_stats endpoint
-		HorizonURL: horizonBaseURL + "/",
-		HTTP:       http.DefaultClient,
-	}
-
 	return func() (uint64, error) {
-		return getFeeFromStats(client, capacityTrigger, percentile, maxOpFeeStroops)
+		return getFeeFromStats(newClient, capacityTrigger, percentile, maxOpFeeStroops)
 	}, nil
 }
 

--- a/support/prefs/prefs.go
+++ b/support/prefs/prefs.go
@@ -1,0 +1,36 @@
+package prefs
+
+import (
+	"fmt"
+	"os"
+)
+
+// Preferences denotes a preferences file
+type Preferences struct {
+	filepath string
+}
+
+// Make creates a new Preferences struct
+func Make(filepath string) *Preferences {
+	return &Preferences{
+		filepath: filepath,
+	}
+}
+
+// FirstTime checks for the existence of the file
+func (p *Preferences) FirstTime() bool {
+	if _, e := os.Stat(p.filepath); os.IsNotExist(e) {
+		return true
+	}
+	return false
+}
+
+// SetNotFirstTime saves a file on the file system to denote that this is not the first time
+func (p *Preferences) SetNotFirstTime() error {
+	emptyFile, e := os.Create(p.filepath)
+	if e != nil {
+		return fmt.Errorf("could not create file '%s' when setting not first time prefs file: %s", p.filepath, e)
+	}
+	emptyFile.Close()
+	return nil
+}

--- a/support/sdk/ccxt.go
+++ b/support/sdk/ccxt.go
@@ -191,12 +191,12 @@ func (c *Ccxt) hasInstance(instanceList []string) bool {
 
 func (c *Ccxt) newInstance(apiKey api.ExchangeAPIKey, params []api.ExchangeParam) error {
 	data := map[string]string{
-		"id": c.instanceName,
+		"id":     c.instanceName,
 		"apiKey": apiKey.Key,
 		"secret": apiKey.Secret,
 	}
 	for _, param := range params {
-		data[param.Parameter] = param.Value
+		data[param.Param] = param.Value
 	}
 	jsonData, e := json.Marshal(data)
 	if e != nil {

--- a/support/sdk/ccxt.go
+++ b/support/sdk/ccxt.go
@@ -24,6 +24,7 @@ type Ccxt struct {
 	exchangeName string
 	instanceName string
 	markets      map[string]CcxtMarket
+	headersMap   map[string]string
 }
 
 // CcxtMarket represents the result of a LoadMarkets call
@@ -52,7 +53,7 @@ type CcxtMarket struct {
 const pathExchanges = "/exchanges"
 
 // MakeInitializedCcxtExchange constructs an instance of Ccxt that is bound to a specific exchange instance on the CCXT REST server
-func MakeInitializedCcxtExchange(exchangeName string, apiKey api.ExchangeAPIKey) (*Ccxt, error) {
+func MakeInitializedCcxtExchange(exchangeName string, apiKey api.ExchangeAPIKey, params []api.ExchangeParam, headers []api.ExchangeHeader) (*Ccxt, error) {
 	if strings.HasSuffix(ccxtBaseURL, "/") {
 		return nil, fmt.Errorf("invalid format for ccxtBaseURL: %s", ccxtBaseURL)
 	}
@@ -67,7 +68,7 @@ func MakeInitializedCcxtExchange(exchangeName string, apiKey api.ExchangeAPIKey)
 		instanceName: instanceName,
 	}
 
-	e = c.initialize(apiKey)
+	e = c.initialize(apiKey, params, headers)
 	if e != nil {
 		return nil, fmt.Errorf("error when initializing Ccxt exchange: %s", e)
 	}
@@ -102,7 +103,7 @@ func loadExchangeList() {
 	exchangeList = &output
 }
 
-func (c *Ccxt) initialize(apiKey api.ExchangeAPIKey) error {
+func (c *Ccxt) initialize(apiKey api.ExchangeAPIKey, params []api.ExchangeParam, headers []api.ExchangeHeader) error {
 	// validate that exchange name is in the exchange list
 	exchangeListed := false
 	el := GetExchangeList()
@@ -125,7 +126,7 @@ func (c *Ccxt) initialize(apiKey api.ExchangeAPIKey) error {
 
 	// make a new instance if needed
 	if !c.hasInstance(instanceList) {
-		e = c.newInstance(apiKey)
+		e = c.newInstance(apiKey, params)
 		if e != nil {
 			return fmt.Errorf("error creating new instance '%s' for exchange '%s': %s", c.instanceName, c.exchangeName, e)
 		}
@@ -148,6 +149,12 @@ func (c *Ccxt) initialize(apiKey api.ExchangeAPIKey) error {
 		return fmt.Errorf("error converting loadMarkets output to a map of Market for exchange instance (exchange=%s, instanceName=%s): %s", c.exchangeName, c.instanceName, e)
 	}
 	c.markets = markets
+
+	headersMap := map[string]string{}
+	for _, header := range headers {
+		headersMap[header.Header] = header.Value
+	}
+	c.headersMap = headersMap
 
 	return nil
 }
@@ -182,22 +189,22 @@ func (c *Ccxt) hasInstance(instanceList []string) bool {
 	return false
 }
 
-func (c *Ccxt) newInstance(apiKey api.ExchangeAPIKey) error {
-	data, e := json.Marshal(&struct {
-		ID     string `json:"id"`
-		APIKey string `json:"apiKey"`
-		Secret string `json:"secret"`
-	}{
-		ID:     c.instanceName,
-		APIKey: apiKey.Key,
-		Secret: apiKey.Secret,
-	})
+func (c *Ccxt) newInstance(apiKey api.ExchangeAPIKey, params []api.ExchangeParam) error {
+	data := map[string]string{
+		"id": c.instanceName,
+		"apiKey": apiKey.Key,
+		"secret": apiKey.Secret,
+	}
+	for _, param := range params {
+		data[param.Parameter] = param.Value
+	}
+	jsonData, e := json.Marshal(data)
 	if e != nil {
 		return fmt.Errorf("error marshaling instanceName '%s' as ID for exchange '%s': %s", c.instanceName, c.exchangeName, e)
 	}
 
 	var newInstance map[string]interface{}
-	e = networking.JSONRequest(c.httpClient, "POST", ccxtBaseURL+pathExchanges+"/"+c.exchangeName, string(data), map[string]string{}, &newInstance, "error")
+	e = networking.JSONRequest(c.httpClient, "POST", ccxtBaseURL+pathExchanges+"/"+c.exchangeName, string(jsonData), c.headersMap, &newInstance, "error")
 	if e != nil {
 		return fmt.Errorf("error in web request when creating new exchange instance for exchange '%s': %s", c.exchangeName, e)
 	}
@@ -214,7 +221,7 @@ func (c *Ccxt) symbolExists(tradingPair string) error {
 	url := ccxtBaseURL + pathExchanges + "/" + c.exchangeName + "/" + c.instanceName
 	// decode generic data (see "https://blog.golang.org/json-and-go#TOC_4.")
 	var exchangeOutput interface{}
-	e := networking.JSONRequest(c.httpClient, "GET", url, "", map[string]string{}, &exchangeOutput, "error")
+	e := networking.JSONRequest(c.httpClient, "GET", url, "", c.headersMap, &exchangeOutput, "error")
 	if e != nil {
 		return fmt.Errorf("error fetching details of exchange instance (exchange=%s, instanceName=%s): %s", c.exchangeName, c.instanceName, e)
 	}
@@ -260,7 +267,7 @@ func (c *Ccxt) FetchTicker(tradingPair string) (map[string]interface{}, error) {
 	url := ccxtBaseURL + pathExchanges + "/" + c.exchangeName + "/" + c.instanceName + "/fetchTicker"
 	// decode generic data (see "https://blog.golang.org/json-and-go#TOC_4.")
 	var output interface{}
-	e = networking.JSONRequest(c.httpClient, "POST", url, string(data), map[string]string{}, &output, "error")
+	e = networking.JSONRequest(c.httpClient, "POST", url, string(data), c.headersMap, &output, "error")
 	if e != nil {
 		return nil, fmt.Errorf("error fetching tickers for trading pair '%s': %s", tradingPair, e)
 	}
@@ -300,7 +307,7 @@ func (c *Ccxt) FetchOrderBook(tradingPair string, limit *int) (map[string][]Ccxt
 	url := ccxtBaseURL + pathExchanges + "/" + c.exchangeName + "/" + c.instanceName + "/fetchOrderBook"
 	// decode generic data (see "https://blog.golang.org/json-and-go#TOC_4.")
 	var output interface{}
-	e = networking.JSONRequest(c.httpClient, "POST", url, string(data), map[string]string{}, &output, "error")
+	e = networking.JSONRequest(c.httpClient, "POST", url, string(data), c.headersMap, &output, "error")
 	if e != nil {
 		return nil, fmt.Errorf("error fetching orderbook for trading pair '%s': %s", tradingPair, e)
 	}
@@ -361,7 +368,7 @@ func (c *Ccxt) FetchTrades(tradingPair string) ([]CcxtTrade, error) {
 	url := ccxtBaseURL + pathExchanges + "/" + c.exchangeName + "/" + c.instanceName + "/fetchTrades"
 	// decode generic data (see "https://blog.golang.org/json-and-go#TOC_4.")
 	output := []CcxtTrade{}
-	e = networking.JSONRequest(c.httpClient, "POST", url, string(data), map[string]string{}, &output, "error")
+	e = networking.JSONRequest(c.httpClient, "POST", url, string(data), c.headersMap, &output, "error")
 	if e != nil {
 		return nil, fmt.Errorf("error fetching trades for trading pair '%s': %s", tradingPair, e)
 	}
@@ -394,7 +401,7 @@ func (c *Ccxt) FetchMyTrades(tradingPair string, limit int, maybeCursorStart int
 	url := ccxtBaseURL + pathExchanges + "/" + c.exchangeName + "/" + c.instanceName + "/fetchMyTrades"
 	// decode generic data (see "https://blog.golang.org/json-and-go#TOC_4.")
 	output := []CcxtTrade{}
-	e = networking.JSONRequest(c.httpClient, "POST", url, string(data), map[string]string{}, &output, "error")
+	e = networking.JSONRequest(c.httpClient, "POST", url, string(data), c.headersMap, &output, "error")
 	if e != nil {
 		return nil, fmt.Errorf("error fetching trades for trading pair '%s': %s", tradingPair, e)
 	}
@@ -413,7 +420,7 @@ func (c *Ccxt) FetchBalance() (map[string]CcxtBalance, error) {
 	url := ccxtBaseURL + pathExchanges + "/" + c.exchangeName + "/" + c.instanceName + "/fetchBalance"
 	// decode generic data (see "https://blog.golang.org/json-and-go#TOC_4.")
 	var output interface{}
-	e := networking.JSONRequest(c.httpClient, "POST", url, "", map[string]string{}, &output, "error")
+	e := networking.JSONRequest(c.httpClient, "POST", url, "", c.headersMap, &output, "error")
 	if e != nil {
 		return nil, fmt.Errorf("error fetching balance: %s", e)
 	}
@@ -479,7 +486,7 @@ func (c *Ccxt) FetchOpenOrders(tradingPairs []string) (map[string][]CcxtOpenOrde
 	url := ccxtBaseURL + pathExchanges + "/" + c.exchangeName + "/" + c.instanceName + "/fetchOpenOrders"
 	// decode generic data (see "https://blog.golang.org/json-and-go#TOC_4.")
 	var output interface{}
-	e = networking.JSONRequest(c.httpClient, "POST", url, string(data), map[string]string{}, &output, "error")
+	e = networking.JSONRequest(c.httpClient, "POST", url, string(data), c.headersMap, &output, "error")
 	if e != nil {
 		return nil, fmt.Errorf("error fetching open orders: %s", e)
 	}
@@ -535,7 +542,7 @@ func (c *Ccxt) CreateLimitOrder(tradingPair string, side string, amount float64,
 	url := ccxtBaseURL + pathExchanges + "/" + c.exchangeName + "/" + c.instanceName + "/createOrder"
 	// decode generic data (see "https://blog.golang.org/json-and-go#TOC_4.")
 	var output interface{}
-	e = networking.JSONRequest(c.httpClient, "POST", url, string(data), map[string]string{}, &output, "error")
+	e = networking.JSONRequest(c.httpClient, "POST", url, string(data), c.headersMap, &output, "error")
 	if e != nil {
 		return nil, fmt.Errorf("error creating order: %s", e)
 	}
@@ -574,7 +581,7 @@ func (c *Ccxt) CancelOrder(orderID string, tradingPair string) (*CcxtOpenOrder, 
 	url := ccxtBaseURL + pathExchanges + "/" + c.exchangeName + "/" + c.instanceName + "/cancelOrder"
 	// decode generic data (see "https://blog.golang.org/json-and-go#TOC_4.")
 	var output interface{}
-	e = networking.JSONRequest(c.httpClient, "POST", url, string(data), map[string]string{}, &output, "error")
+	e = networking.JSONRequest(c.httpClient, "POST", url, string(data), c.headersMap, &output, "error")
 	if e != nil {
 		return nil, fmt.Errorf("error canceling order: %s", e)
 	}

--- a/support/sdk/ccxt_test.go
+++ b/support/sdk/ccxt_test.go
@@ -42,7 +42,7 @@ func TestMakeValid(t *testing.T) {
 		return
 	}
 
-	_, e := MakeInitializedCcxtExchange("kraken", api.ExchangeAPIKey{})
+	_, e := MakeInitializedCcxtExchange("kraken", api.ExchangeAPIKey{}, []api.ExchangeParam{}, []api.ExchangeHeader{})
 	if e != nil {
 		assert.Fail(t, fmt.Sprintf("unexpected error: %s", e))
 		return
@@ -55,7 +55,7 @@ func TestMakeInvalid(t *testing.T) {
 		return
 	}
 
-	_, e := MakeInitializedCcxtExchange("missing-exchange", api.ExchangeAPIKey{})
+	_, e := MakeInitializedCcxtExchange("missing-exchange", api.ExchangeAPIKey{}, []api.ExchangeParam{}, []api.ExchangeHeader{})
 	if e == nil {
 		assert.Fail(t, "expected an error when trying to make and initialize an exchange that is missing: 'missing-exchange'")
 		return
@@ -73,7 +73,7 @@ func TestFetchTickers(t *testing.T) {
 		return
 	}
 
-	c, e := MakeInitializedCcxtExchange("binance", api.ExchangeAPIKey{})
+	c, e := MakeInitializedCcxtExchange("binance", api.ExchangeAPIKey{}, []api.ExchangeParam{}, []api.ExchangeHeader{})
 	if e != nil {
 		assert.Fail(t, fmt.Sprintf("error when making ccxt exchange: %s", e))
 		return
@@ -94,7 +94,7 @@ func TestFetchTickersWithMissingSymbol(t *testing.T) {
 		return
 	}
 
-	c, e := MakeInitializedCcxtExchange("binance", api.ExchangeAPIKey{})
+	c, e := MakeInitializedCcxtExchange("binance", api.ExchangeAPIKey{}, []api.ExchangeParam{}, []api.ExchangeHeader{})
 	if e != nil {
 		assert.Fail(t, fmt.Sprintf("error when making ccxt exchange: %s", e))
 		return
@@ -183,7 +183,7 @@ func runTestFetchOrderBook(k orderbookTest, t *testing.T) {
 		return
 	}
 
-	c, e := MakeInitializedCcxtExchange(k.exchangeName, api.ExchangeAPIKey{})
+	c, e := MakeInitializedCcxtExchange(k.exchangeName, api.ExchangeAPIKey{}, []api.ExchangeParam{}, []api.ExchangeHeader{})
 	if e != nil {
 		assert.Fail(t, fmt.Sprintf("error when making ccxt exchange: %s", e))
 		return
@@ -256,7 +256,7 @@ func TestFetchTrades(t *testing.T) {
 	} {
 		tradingPairString := strings.Replace(k.tradingPair, "/", "_", -1)
 		t.Run(fmt.Sprintf("%s-%s", k.exchangeName, tradingPairString), func(t *testing.T) {
-			c, e := MakeInitializedCcxtExchange(k.exchangeName, api.ExchangeAPIKey{})
+			c, e := MakeInitializedCcxtExchange(k.exchangeName, api.ExchangeAPIKey{}, []api.ExchangeParam{}, []api.ExchangeHeader{})
 			if e != nil {
 				assert.Fail(t, fmt.Sprintf("error when making ccxt exchange: %s", e))
 				return
@@ -311,7 +311,7 @@ func TestFetchMyTrades(t *testing.T) {
 	} {
 		tradingPairString := strings.Replace(k.tradingPair, "/", "_", -1)
 		t.Run(fmt.Sprintf("%s-%s", k.exchangeName, tradingPairString), func(t *testing.T) {
-			c, e := MakeInitializedCcxtExchange(k.exchangeName, k.apiKey)
+			c, e := MakeInitializedCcxtExchange(k.exchangeName, k.apiKey, []api.ExchangeParam{}, []api.ExchangeHeader{})
 			if e != nil {
 				assert.Fail(t, fmt.Sprintf("error when making ccxt exchange: %s", e))
 				return
@@ -388,7 +388,7 @@ func TestFetchBalance(t *testing.T) {
 		},
 	} {
 		t.Run(k.exchangeName, func(t *testing.T) {
-			c, e := MakeInitializedCcxtExchange(k.exchangeName, k.apiKey)
+			c, e := MakeInitializedCcxtExchange(k.exchangeName, k.apiKey, []api.ExchangeParam{}, []api.ExchangeHeader{})
 			if e != nil {
 				assert.Fail(t, fmt.Sprintf("error when making ccxt exchange: %s", e))
 				return
@@ -436,7 +436,7 @@ func TestOpenOrders(t *testing.T) {
 		},
 	} {
 		t.Run(k.exchangeName, func(t *testing.T) {
-			c, e := MakeInitializedCcxtExchange(k.exchangeName, k.apiKey)
+			c, e := MakeInitializedCcxtExchange(k.exchangeName, k.apiKey, []api.ExchangeParam{}, []api.ExchangeHeader{})
 			if e != nil {
 				assert.Fail(t, fmt.Sprintf("error when making ccxt exchange: %s", e))
 				return
@@ -519,7 +519,7 @@ func TestCreateLimitOrder(t *testing.T) {
 		},
 	} {
 		t.Run(k.exchangeName, func(t *testing.T) {
-			c, e := MakeInitializedCcxtExchange(k.exchangeName, k.apiKey)
+			c, e := MakeInitializedCcxtExchange(k.exchangeName, k.apiKey, []api.ExchangeParam{}, []api.ExchangeHeader{})
 			if e != nil {
 				assert.Fail(t, fmt.Sprintf("error when making ccxt exchange: %s", e))
 				return
@@ -604,7 +604,7 @@ func TestCancelOrder(t *testing.T) {
 		},
 	} {
 		t.Run(k.exchangeName, func(t *testing.T) {
-			c, e := MakeInitializedCcxtExchange(k.exchangeName, k.apiKey)
+			c, e := MakeInitializedCcxtExchange(k.exchangeName, k.apiKey, []api.ExchangeParam{}, []api.ExchangeHeader{})
 			if e != nil {
 				assert.Fail(t, fmt.Sprintf("error when making ccxt exchange: %s", e))
 				return

--- a/support/utils/configs.go
+++ b/support/utils/configs.go
@@ -79,3 +79,21 @@ func passthrough(i interface{}) interface{} {
 func Hide(i interface{}) interface{} {
 	return ""
 }
+
+// UnwrapFloat64Pointer unwraps a float64 pointer
+func UnwrapFloat64Pointer(i interface{}) interface{} {
+	p := i.(*float64)
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+// UnwrapInt8Pointer unwraps a int8 pointer
+func UnwrapInt8Pointer(i interface{}) interface{} {
+	p := i.(*int8)
+	if p == nil {
+		return ""
+	}
+	return *p
+}

--- a/trader/config.go
+++ b/trader/config.go
@@ -19,31 +19,34 @@ type FeeConfig struct {
 
 // BotConfig represents the configuration params for the bot
 type BotConfig struct {
-	SourceSecretSeed                 string     `valid:"-" toml:"SOURCE_SECRET_SEED"`
-	TradingSecretSeed                string     `valid:"-" toml:"TRADING_SECRET_SEED"`
-	AssetCodeA                       string     `valid:"-" toml:"ASSET_CODE_A"`
-	IssuerA                          string     `valid:"-" toml:"ISSUER_A"`
-	AssetCodeB                       string     `valid:"-" toml:"ASSET_CODE_B"`
-	IssuerB                          string     `valid:"-" toml:"ISSUER_B"`
-	TickIntervalSeconds              int32      `valid:"-" toml:"TICK_INTERVAL_SECONDS"`
-	MaxTickDelayMillis               int64      `valid:"-" toml:"MAX_TICK_DELAY_MILLIS"`
-	DeleteCyclesThreshold            int64      `valid:"-" toml:"DELETE_CYCLES_THRESHOLD"`
-	SubmitMode                       string     `valid:"-" toml:"SUBMIT_MODE"`
-	FillTrackerSleepMillis           uint32     `valid:"-" toml:"FILL_TRACKER_SLEEP_MILLIS"`
-	FillTrackerDeleteCyclesThreshold int64      `valid:"-" toml:"FILL_TRACKER_DELETE_CYCLES_THRESHOLD"`
-	HorizonURL                       string     `valid:"-" toml:"HORIZON_URL"`
-	Fee                              *FeeConfig `valid:"-" toml:"FEE"`
-	MinCentralizedBaseVolume         float64    `valid:"-" toml:"MIN_CENTRALIZED_BASE_VOLUME"`
-	AlertType                        string     `valid:"-" toml:"ALERT_TYPE"`
-	AlertAPIKey                      string     `valid:"-" toml:"ALERT_API_KEY"`
-	MonitoringPort                   uint16     `valid:"-" toml:"MONITORING_PORT"`
-	MonitoringTLSCert                string     `valid:"-" toml:"MONITORING_TLS_CERT"`
-	MonitoringTLSKey                 string     `valid:"-" toml:"MONITORING_TLS_KEY"`
-	GoogleClientID                   string     `valid:"-" toml:"GOOGLE_CLIENT_ID"`
-	GoogleClientSecret               string     `valid:"-" toml:"GOOGLE_CLIENT_SECRET"`
-	AcceptableEmails                 string     `valid:"-" toml:"ACCEPTABLE_GOOGLE_EMAILS"`
-	TradingExchange                  string     `valid:"-" toml:"TRADING_EXCHANGE"`
-	ExchangeAPIKeys                  []struct {
+	SourceSecretSeed                   string     `valid:"-" toml:"SOURCE_SECRET_SEED"`
+	TradingSecretSeed                  string     `valid:"-" toml:"TRADING_SECRET_SEED"`
+	AssetCodeA                         string     `valid:"-" toml:"ASSET_CODE_A"`
+	IssuerA                            string     `valid:"-" toml:"ISSUER_A"`
+	AssetCodeB                         string     `valid:"-" toml:"ASSET_CODE_B"`
+	IssuerB                            string     `valid:"-" toml:"ISSUER_B"`
+	TickIntervalSeconds                int32      `valid:"-" toml:"TICK_INTERVAL_SECONDS"`
+	MaxTickDelayMillis                 int64      `valid:"-" toml:"MAX_TICK_DELAY_MILLIS"`
+	DeleteCyclesThreshold              int64      `valid:"-" toml:"DELETE_CYCLES_THRESHOLD"`
+	SubmitMode                         string     `valid:"-" toml:"SUBMIT_MODE"`
+	FillTrackerSleepMillis             uint32     `valid:"-" toml:"FILL_TRACKER_SLEEP_MILLIS"`
+	FillTrackerDeleteCyclesThreshold   int64      `valid:"-" toml:"FILL_TRACKER_DELETE_CYCLES_THRESHOLD"`
+	HorizonURL                         string     `valid:"-" toml:"HORIZON_URL"`
+	Fee                                *FeeConfig `valid:"-" toml:"FEE"`
+	CentralizedPricePrecisionOverride  *int8      `valid:"-" toml:"CENTRALIZED_PRICE_PRECISION_OVERRIDE"`
+	CentralizedVolumePrecisionOverride *int8      `valid:"-" toml:"CENTRALIZED_VOLUME_PRECISION_OVERRIDE"`
+	CentralizedMinBaseVolumeOverride   *float64   `valid:"-" toml:"CENTRALIZED_MIN_BASE_VOLUME_OVERRIDE"`
+	CentralizedMinQuoteVolumeOverride  *float64   `valid:"-" toml:"CENTRALIZED_MIN_QUOTE_VOLUME_OVERRIDE"`
+	AlertType                          string     `valid:"-" toml:"ALERT_TYPE"`
+	AlertAPIKey                        string     `valid:"-" toml:"ALERT_API_KEY"`
+	MonitoringPort                     uint16     `valid:"-" toml:"MONITORING_PORT"`
+	MonitoringTLSCert                  string     `valid:"-" toml:"MONITORING_TLS_CERT"`
+	MonitoringTLSKey                   string     `valid:"-" toml:"MONITORING_TLS_KEY"`
+	GoogleClientID                     string     `valid:"-" toml:"GOOGLE_CLIENT_ID"`
+	GoogleClientSecret                 string     `valid:"-" toml:"GOOGLE_CLIENT_SECRET"`
+	AcceptableEmails                   string     `valid:"-" toml:"ACCEPTABLE_GOOGLE_EMAILS"`
+	TradingExchange                    string     `valid:"-" toml:"TRADING_EXCHANGE"`
+	ExchangeAPIKeys                    []struct {
 		Key    string `valid:"-" toml:"KEY"`
 		Secret string `valid:"-" toml:"SECRET"`
 	} `valid:"-" toml:"EXCHANGE_API_KEYS"`
@@ -59,13 +62,17 @@ type BotConfig struct {
 // String impl.
 func (b BotConfig) String() string {
 	return utils.StructString(b, map[string]func(interface{}) interface{}{
-		"EXCHANGE_API_KEYS":        utils.Hide,
-		"SOURCE_SECRET_SEED":       utils.SecretKey2PublicKey,
-		"TRADING_SECRET_SEED":      utils.SecretKey2PublicKey,
-		"ALERT_API_KEY":            utils.Hide,
-		"GOOGLE_CLIENT_ID":         utils.Hide,
-		"GOOGLE_CLIENT_SECRET":     utils.Hide,
-		"ACCEPTABLE_GOOGLE_EMAILS": utils.Hide,
+		"EXCHANGE_API_KEYS":                     utils.Hide,
+		"SOURCE_SECRET_SEED":                    utils.SecretKey2PublicKey,
+		"TRADING_SECRET_SEED":                   utils.SecretKey2PublicKey,
+		"ALERT_API_KEY":                         utils.Hide,
+		"GOOGLE_CLIENT_ID":                      utils.Hide,
+		"GOOGLE_CLIENT_SECRET":                  utils.Hide,
+		"ACCEPTABLE_GOOGLE_EMAILS":              utils.Hide,
+		"CENTRALIZED_PRICE_PRECISION_OVERRIDE":  utils.UnwrapInt8Pointer,
+		"CENTRALIZED_VOLUME_PRECISION_OVERRIDE": utils.UnwrapInt8Pointer,
+		"CENTRALIZED_MIN_BASE_VOLUME_OVERRIDE":  utils.UnwrapFloat64Pointer,
+		"CENTRALIZED_MIN_QUOTE_VOLUME_OVERRIDE": utils.UnwrapFloat64Pointer,
 	})
 }
 

--- a/trader/config.go
+++ b/trader/config.go
@@ -50,6 +50,14 @@ type BotConfig struct {
 		Key    string `valid:"-" toml:"KEY"`
 		Secret string `valid:"-" toml:"SECRET"`
 	} `valid:"-" toml:"EXCHANGE_API_KEYS"`
+	ExchangeParams []struct {
+		Parameter string `valid:"-" toml:"PARAMETER"`
+		Value     string `valid:"-" toml:"VALUE"`
+	} `valid:"-" toml:"EXCHANGE_PARAMS"`
+	ExchangeHeaders []struct {
+		Header string `valid:"-" toml:"HEADER"`
+		Value  string `valid:"-" toml:"VALUE"`
+	} `valid:"-" toml:"EXCHANGE_HEADERS"`
 
 	// initialized later
 	tradingAccount *string
@@ -63,6 +71,8 @@ type BotConfig struct {
 func (b BotConfig) String() string {
 	return utils.StructString(b, map[string]func(interface{}) interface{}{
 		"EXCHANGE_API_KEYS":                     utils.Hide,
+		"EXCHANGE_PARAMS":                       utils.Hide,
+		"EXCHANGE_HEADERS":                      utils.Hide,
 		"SOURCE_SECRET_SEED":                    utils.SecretKey2PublicKey,
 		"TRADING_SECRET_SEED":                   utils.SecretKey2PublicKey,
 		"ALERT_API_KEY":                         utils.Hide,

--- a/trader/config.go
+++ b/trader/config.go
@@ -51,8 +51,8 @@ type BotConfig struct {
 		Secret string `valid:"-" toml:"SECRET"`
 	} `valid:"-" toml:"EXCHANGE_API_KEYS"`
 	ExchangeParams []struct {
-		Parameter string `valid:"-" toml:"PARAMETER"`
-		Value     string `valid:"-" toml:"VALUE"`
+		Param string `valid:"-" toml:"PARAM"`
+		Value string `valid:"-" toml:"VALUE"`
 	} `valid:"-" toml:"EXCHANGE_PARAMS"`
 	ExchangeHeaders []struct {
 		Header string `valid:"-" toml:"HEADER"`


### PR DESCRIPTION
This pr implements the feature requested in https://github.com/stellar/kelp/issues/139 by allowing users to specify any additional ccxt parameters and/or http headers they may need to add to their API requests. I have live tested it on Coinbase Pro, so if this is implemented we can marked Coinbase Pro as tested.