### PR TITLE
Override price vol precision and minQuoteVol, closes #141, closes #152

### DIFF
--- a/api/exchange.go
+++ b/api/exchange.go
@@ -73,6 +73,8 @@ type FillTrackable interface {
 type Constrainable interface {
 	// return nil if the constraint does not exist for the exchange
 	GetOrderConstraints(pair *model.TradingPair) *model.OrderConstraints
+
+	OverrideOrderConstraints(pair *model.TradingPair, override *model.OrderConstraintsOverride)
 }
 
 // OrderbookFetcher extracts out the method that should go into ExchangeShim for now

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -96,6 +96,9 @@ func validateBotConfig(l logger.Logger, botConfig trader.BotConfig) {
 	if !botConfig.IsTradingSdex() && botConfig.CentralizedMinBaseVolumeOverride != nil && *botConfig.CentralizedMinBaseVolumeOverride <= 0.0 {
 		logger.Fatal(l, fmt.Errorf("need to specify positive CENTRALIZED_MIN_BASE_VOLUME_OVERRIDE config param in trader config file when not trading on SDEX"))
 	}
+	if !botConfig.IsTradingSdex() && botConfig.CentralizedMinQuoteVolumeOverride != nil && *botConfig.CentralizedMinQuoteVolumeOverride <= 0.0 {
+		logger.Fatal(l, fmt.Errorf("need to specify positive CENTRALIZED_MIN_QUOTE_VOLUME_OVERRIDE config param in trader config file when not trading on SDEX"))
+	}
 	validatePrecisionConfig(l, botConfig.IsTradingSdex(), botConfig.CentralizedVolumePrecisionOverride, "CENTRALIZED_VOLUME_PRECISION_OVERRIDE")
 	validatePrecisionConfig(l, botConfig.IsTradingSdex(), botConfig.CentralizedPricePrecisionOverride, "CENTRALIZED_PRICE_PRECISION_OVERRIDE")
 }
@@ -225,6 +228,16 @@ func makeExchangeShimSdex(
 				nil,
 				model.NumberFromFloat(*botConfig.CentralizedMinBaseVolumeOverride, exchangeShim.GetOrderConstraints(tradingPair).VolumePrecision),
 				nil,
+			))
+		}
+		if botConfig.CentralizedMinQuoteVolumeOverride != nil {
+			// use updated precision overrides to convert the minCentralizedQuoteVolume to a model.Number
+			minQuoteVolume := model.NumberFromFloat(*botConfig.CentralizedMinQuoteVolumeOverride, exchangeShim.GetOrderConstraints(tradingPair).VolumePrecision)
+			exchangeShim.OverrideOrderConstraints(tradingPair, model.MakeOrderConstraintsOverride(
+				nil,
+				nil,
+				nil,
+				&minQuoteVolume,
 			))
 		}
 	}

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -93,8 +93,8 @@ func validateBotConfig(l logger.Logger, botConfig trader.BotConfig) {
 		logger.Fatal(l, fmt.Errorf("The `FEE` object needs to exist in the trader config file when trading on SDEX"))
 	}
 
-	if !botConfig.IsTradingSdex() && botConfig.MinCentralizedBaseVolumeOverride != nil && *botConfig.MinCentralizedBaseVolumeOverride <= 0.0 {
-		logger.Fatal(l, fmt.Errorf("need to specify positive MIN_CENTRALIZED_BASE_VOLUME_OVERRIDE config param in trader config file when not trading on SDEX"))
+	if !botConfig.IsTradingSdex() && botConfig.CentralizedMinBaseVolumeOverride != nil && *botConfig.CentralizedMinBaseVolumeOverride <= 0.0 {
+		logger.Fatal(l, fmt.Errorf("need to specify positive CENTRALIZED_MIN_BASE_VOLUME_OVERRIDE config param in trader config file when not trading on SDEX"))
 	}
 	validatePrecisionConfig(l, botConfig.IsTradingSdex(), botConfig.CentralizedVolumePrecisionOverride, "CENTRALIZED_VOLUME_PRECISION_OVERRIDE")
 	validatePrecisionConfig(l, botConfig.IsTradingSdex(), botConfig.CentralizedPricePrecisionOverride, "CENTRALIZED_PRICE_PRECISION_OVERRIDE")
@@ -218,12 +218,12 @@ func makeExchangeShimSdex(
 			nil,
 			nil,
 		))
-		if botConfig.MinCentralizedBaseVolumeOverride != nil {
+		if botConfig.CentralizedMinBaseVolumeOverride != nil {
 			// use updated precision overrides to convert the minCentralizedBaseVolume to a model.Number
 			exchangeShim.OverrideOrderConstraints(tradingPair, model.MakeOrderConstraintsOverride(
 				nil,
 				nil,
-				model.NumberFromFloat(*botConfig.MinCentralizedBaseVolumeOverride, exchangeShim.GetOrderConstraints(tradingPair).VolumePrecision),
+				model.NumberFromFloat(*botConfig.CentralizedMinBaseVolumeOverride, exchangeShim.GetOrderConstraints(tradingPair).VolumePrecision),
 				nil,
 			))
 		}

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -102,9 +102,7 @@ func validateBotConfig(l logger.Logger, botConfig trader.BotConfig) {
 }
 
 func validatePrecisionConfig(l logger.Logger, isTradingSdex bool, precisionField *int8, name string) {
-	if !isTradingSdex && precisionField == nil {
-		logger.Fatal(l, fmt.Errorf("need to specify %s config param in trader config file when not trading on SDEX", name))
-	} else if !isTradingSdex && *precisionField < 0 {
+	if !isTradingSdex && precisionField != nil && *precisionField < 0 {
 		logger.Fatal(l, fmt.Errorf("need to specify non-negative %s config param in trader config file when not trading on SDEX", name))
 	}
 }

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -96,6 +96,17 @@ func validateBotConfig(l logger.Logger, botConfig trader.BotConfig) {
 	if !botConfig.IsTradingSdex() && botConfig.MinCentralizedBaseVolume == 0.0 {
 		logger.Fatal(l, fmt.Errorf("need to specify non-zero MIN_CENTRALIZED_BASE_VOLUME config param in trader config file when not trading on SDEX"))
 	}
+
+	validatePrecisionConfig(l, botConfig.IsTradingSdex(), botConfig.CentralizedVolumePrecisionOverride, "CENTRALIZED_VOLUME_PRECISION_OVERRIDE")
+	validatePrecisionConfig(l, botConfig.IsTradingSdex(), botConfig.CentralizedPricePrecisionOverride, "CENTRALIZED_PRICE_PRECISION_OVERRIDE")
+}
+
+func validatePrecisionConfig(l logger.Logger, isTradingSdex bool, precisionField *int8, name string) {
+	if !isTradingSdex && precisionField == nil {
+		logger.Fatal(l, fmt.Errorf("need to specify %s config param in trader config file when not trading on SDEX", name))
+	} else if !isTradingSdex && *precisionField < 0 {
+		logger.Fatal(l, fmt.Errorf("need to specify non-negative %s config param in trader config file when not trading on SDEX", name))
+	}
 }
 
 func init() {

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -93,10 +93,9 @@ func validateBotConfig(l logger.Logger, botConfig trader.BotConfig) {
 		logger.Fatal(l, fmt.Errorf("The `FEE` object needs to exist in the trader config file when trading on SDEX"))
 	}
 
-	if !botConfig.IsTradingSdex() && botConfig.MinCentralizedBaseVolume == 0.0 {
-		logger.Fatal(l, fmt.Errorf("need to specify non-zero MIN_CENTRALIZED_BASE_VOLUME config param in trader config file when not trading on SDEX"))
+	if !botConfig.IsTradingSdex() && botConfig.MinCentralizedBaseVolumeOverride != nil && *botConfig.MinCentralizedBaseVolumeOverride <= 0.0 {
+		logger.Fatal(l, fmt.Errorf("need to specify positive MIN_CENTRALIZED_BASE_VOLUME_OVERRIDE config param in trader config file when not trading on SDEX"))
 	}
-
 	validatePrecisionConfig(l, botConfig.IsTradingSdex(), botConfig.CentralizedVolumePrecisionOverride, "CENTRALIZED_VOLUME_PRECISION_OVERRIDE")
 	validatePrecisionConfig(l, botConfig.IsTradingSdex(), botConfig.CentralizedPricePrecisionOverride, "CENTRALIZED_PRICE_PRECISION_OVERRIDE")
 }
@@ -219,13 +218,15 @@ func makeExchangeShimSdex(
 			nil,
 			nil,
 		))
-		// use updated precision overrides to convert the minCentralizedBaseVolume to a model.Number
-		exchangeShim.OverrideOrderConstraints(tradingPair, model.MakeOrderConstraintsOverride(
-			nil,
-			nil,
-			model.NumberFromFloat(botConfig.MinCentralizedBaseVolume, exchangeShim.GetOrderConstraints(tradingPair).VolumePrecision),
-			nil,
-		))
+		if botConfig.MinCentralizedBaseVolumeOverride != nil {
+			// use updated precision overrides to convert the minCentralizedBaseVolume to a model.Number
+			exchangeShim.OverrideOrderConstraints(tradingPair, model.MakeOrderConstraintsOverride(
+				nil,
+				nil,
+				model.NumberFromFloat(*botConfig.MinCentralizedBaseVolumeOverride, exchangeShim.GetOrderConstraints(tradingPair).VolumePrecision),
+				nil,
+			))
+		}
 	}
 
 	sdexAssetMap := map[model.Asset]horizon.Asset{

--- a/examples/configs/trader/sample_mirror.cfg
+++ b/examples/configs/trader/sample_mirror.cfg
@@ -36,13 +36,13 @@ VOLUME_DIVIDE_BY=500.0
 # in this example the spread is 0.5%
 PER_LEVEL_SPREAD=0.005
 
-# minimum volume of base units needed to place an order on the backing exchange
+# (optional) minimum volume of base units needed to place an order on the backing exchange
 # minimum values for Kraken: https://support.kraken.com/hc/en-us/articles/205893708-What-is-the-minimum-order-size-volume-
 # minimum order value for Binance: https://support.binance.com/hc/en-us/articles/115000594711-Trading-Rule
-MIN_BASE_VOLUME=30.0
-# number of decimal units to be used for volume, which is specified in units of the base asset, needed to place an order on the backing exchange
+# MIN_BASE_VOLUME_OVERRIDE=30.0
+# (optional) number of decimal units to be used for volume, which is specified in units of the base asset, needed to place an order on the backing exchange
 #VOLUME_PRECISION_OVERRIDE=1
-# number of decimal units to be used for price, which is specified in units of the quote asset, needed to place an order on the backing exchange
+# (optional) number of decimal units to be used for price, which is specified in units of the quote asset, needed to place an order on the backing exchange
 #PRICE_PRECISION_OVERRIDE=6
 
 # set to true if you want the bot to offset your trades onto the backing exchange to realize the per_level_spread against each trade

--- a/examples/configs/trader/sample_mirror.cfg
+++ b/examples/configs/trader/sample_mirror.cfg
@@ -40,6 +40,10 @@ PER_LEVEL_SPREAD=0.005
 # minimum values for Kraken: https://support.kraken.com/hc/en-us/articles/205893708-What-is-the-minimum-order-size-volume-
 # minimum order value for Binance: https://support.binance.com/hc/en-us/articles/115000594711-Trading-Rule
 MIN_BASE_VOLUME=30.0
+# number of decimal units to be used for volume, which is specified in units of the base asset, needed to place an order on the backing exchange
+#VOLUME_PRECISION_OVERRIDE=1
+# number of decimal units to be used for price, which is specified in units of the quote asset, needed to place an order on the backing exchange
+#PRICE_PRECISION_OVERRIDE=6
 
 # set to true if you want the bot to offset your trades onto the backing exchange to realize the per_level_spread against each trade
 # requires you to specify the EXCHANGE_API_KEYS below

--- a/examples/configs/trader/sample_mirror.cfg
+++ b/examples/configs/trader/sample_mirror.cfg
@@ -36,14 +36,14 @@ VOLUME_DIVIDE_BY=500.0
 # in this example the spread is 0.5%
 PER_LEVEL_SPREAD=0.005
 
-# (optional) minimum volume of base units needed to place an order on the backing exchange
 # minimum values for Kraken: https://support.kraken.com/hc/en-us/articles/205893708-What-is-the-minimum-order-size-volume-
 # minimum order value for Binance: https://support.binance.com/hc/en-us/articles/115000594711-Trading-Rule
-# MIN_BASE_VOLUME_OVERRIDE=30.0
-# (optional) number of decimal units to be used for volume, which is specified in units of the base asset, needed to place an order on the backing exchange
-#VOLUME_PRECISION_OVERRIDE=1
 # (optional) number of decimal units to be used for price, which is specified in units of the quote asset, needed to place an order on the backing exchange
 #PRICE_PRECISION_OVERRIDE=6
+# (optional) number of decimal units to be used for volume, which is specified in units of the base asset, needed to place an order on the backing exchange
+#VOLUME_PRECISION_OVERRIDE=1
+# (optional) minimum volume of base units needed to place an order on the backing exchange
+#MIN_BASE_VOLUME_OVERRIDE=30.0
 
 # set to true if you want the bot to offset your trades onto the backing exchange to realize the per_level_spread against each trade
 # requires you to specify the EXCHANGE_API_KEYS below

--- a/examples/configs/trader/sample_mirror.cfg
+++ b/examples/configs/trader/sample_mirror.cfg
@@ -44,6 +44,8 @@ PER_LEVEL_SPREAD=0.005
 #VOLUME_PRECISION_OVERRIDE=1
 # (optional) minimum volume of base units needed to place an order on the backing exchange
 #MIN_BASE_VOLUME_OVERRIDE=30.0
+# (optional) minimum volume of quote units needed to place an order on the backing exchange
+#MIN_QUOTE_VOLUME_OVERRIDE=30.0
 
 # set to true if you want the bot to offset your trades onto the backing exchange to realize the per_level_spread against each trade
 # requires you to specify the EXCHANGE_API_KEYS below

--- a/examples/configs/trader/sample_trader.cfg
+++ b/examples/configs/trader/sample_trader.cfg
@@ -93,6 +93,8 @@ MAX_OP_FEE_STROOPS=5000
 #CENTRALIZED_VOLUME_PRECISION_OVERRIDE=1
 # (optional) minimum volume of base units needed to place an order on the non-sdex (centralized) exchange
 #CENTRALIZED_MIN_BASE_VOLUME_OVERRIDE=30.0
+# (optional) minimum volume of quote units needed to place an order on the non-sdex (centralized) exchange
+#CENTRALIZED_MIN_QUOTE_VOLUME_OVERRIDE=10.0
 
 # uncomment lines below to use kraken. Can use "sdex" or leave out to trade on the Stellar Decentralized Exchange.
 # can alternatively use any of the ccxt-exchanges marked as "Trading" (run `kelp exchanges` for full list)

--- a/examples/configs/trader/sample_trader.cfg
+++ b/examples/configs/trader/sample_trader.cfg
@@ -88,7 +88,7 @@ MAX_OP_FEE_STROOPS=5000
 # (optional) minimum volume of base units needed to place an order on the non-sdex (centralized) exchange
 # minimum values for Kraken: https://support.kraken.com/hc/en-us/articles/205893708-What-is-the-minimum-order-size-volume-
 # minimum order value for Binance: https://support.binance.com/hc/en-us/articles/115000594711-Trading-Rule
-#MIN_CENTRALIZED_BASE_VOLUME_OVERRIDE=30.0
+#CENTRALIZED_MIN_BASE_VOLUME_OVERRIDE=30.0
 # (optional) number of decimal units to be used for volume, which is specified in units of the base asset, to place an order on the non-sdex (centralized) exchange
 #CENTRALIZED_VOLUME_PRECISION_OVERRIDE=1
 # (optional) number of decimal units to be used for price, which is specified in units of the quote asset, to place an order on the non-sdex (centralized) exchange

--- a/examples/configs/trader/sample_trader.cfg
+++ b/examples/configs/trader/sample_trader.cfg
@@ -85,13 +85,13 @@ MAX_OP_FEE_STROOPS=5000
 # Google authentication.
 #ACCEPTABLE_GOOGLE_EMAILS=""
 
-# minimum volume of base units needed to place an order on the non-sdex (centralized) exchange
+# (optional) minimum volume of base units needed to place an order on the non-sdex (centralized) exchange
 # minimum values for Kraken: https://support.kraken.com/hc/en-us/articles/205893708-What-is-the-minimum-order-size-volume-
 # minimum order value for Binance: https://support.binance.com/hc/en-us/articles/115000594711-Trading-Rule
-#MIN_CENTRALIZED_BASE_VOLUME=30.0
-# number of decimal units to be used for volume, which is specified in units of the base asset, to place an order on the non-sdex (centralized) exchange
+#MIN_CENTRALIZED_BASE_VOLUME_OVERRIDE=30.0
+# (optional) number of decimal units to be used for volume, which is specified in units of the base asset, to place an order on the non-sdex (centralized) exchange
 #CENTRALIZED_VOLUME_PRECISION_OVERRIDE=1
-# number of decimal units to be used for price, which is specified in units of the quote asset, to place an order on the non-sdex (centralized) exchange
+# (optional) number of decimal units to be used for price, which is specified in units of the quote asset, to place an order on the non-sdex (centralized) exchange
 #CENTRALIZED_PRICE_PRECISION_OVERRIDE=6
 # uncomment lines below to use kraken. Can use "sdex" or leave out to trade on the Stellar Decentralized Exchange.
 # can alternatively use any of the ccxt-exchanges marked as "Trading" (run `kelp exchanges` for full list)

--- a/examples/configs/trader/sample_trader.cfg
+++ b/examples/configs/trader/sample_trader.cfg
@@ -89,6 +89,10 @@ MAX_OP_FEE_STROOPS=5000
 # minimum values for Kraken: https://support.kraken.com/hc/en-us/articles/205893708-What-is-the-minimum-order-size-volume-
 # minimum order value for Binance: https://support.binance.com/hc/en-us/articles/115000594711-Trading-Rule
 #MIN_CENTRALIZED_BASE_VOLUME=30.0
+# number of decimal units to be used for volume, which is specified in units of the base asset, to place an order on the non-sdex (centralized) exchange
+#CENTRALIZED_VOLUME_PRECISION_OVERRIDE=1
+# number of decimal units to be used for price, which is specified in units of the quote asset, to place an order on the non-sdex (centralized) exchange
+#CENTRALIZED_PRICE_PRECISION_OVERRIDE=6
 # uncomment lines below to use kraken. Can use "sdex" or leave out to trade on the Stellar Decentralized Exchange.
 # can alternatively use any of the ccxt-exchanges marked as "Trading" (run `kelp exchanges` for full list)
 #TRADING_EXCHANGE="kraken"

--- a/examples/configs/trader/sample_trader.cfg
+++ b/examples/configs/trader/sample_trader.cfg
@@ -85,14 +85,15 @@ MAX_OP_FEE_STROOPS=5000
 # Google authentication.
 #ACCEPTABLE_GOOGLE_EMAILS=""
 
-# (optional) minimum volume of base units needed to place an order on the non-sdex (centralized) exchange
 # minimum values for Kraken: https://support.kraken.com/hc/en-us/articles/205893708-What-is-the-minimum-order-size-volume-
 # minimum order value for Binance: https://support.binance.com/hc/en-us/articles/115000594711-Trading-Rule
-#CENTRALIZED_MIN_BASE_VOLUME_OVERRIDE=30.0
-# (optional) number of decimal units to be used for volume, which is specified in units of the base asset, to place an order on the non-sdex (centralized) exchange
-#CENTRALIZED_VOLUME_PRECISION_OVERRIDE=1
 # (optional) number of decimal units to be used for price, which is specified in units of the quote asset, to place an order on the non-sdex (centralized) exchange
 #CENTRALIZED_PRICE_PRECISION_OVERRIDE=6
+# (optional) number of decimal units to be used for volume, which is specified in units of the base asset, to place an order on the non-sdex (centralized) exchange
+#CENTRALIZED_VOLUME_PRECISION_OVERRIDE=1
+# (optional) minimum volume of base units needed to place an order on the non-sdex (centralized) exchange
+#CENTRALIZED_MIN_BASE_VOLUME_OVERRIDE=30.0
+
 # uncomment lines below to use kraken. Can use "sdex" or leave out to trade on the Stellar Decentralized Exchange.
 # can alternatively use any of the ccxt-exchanges marked as "Trading" (run `kelp exchanges` for full list)
 #TRADING_EXCHANGE="kraken"

--- a/model/orderbook.go
+++ b/model/orderbook.go
@@ -305,6 +305,28 @@ func MakeOrderConstraintsWithCost(pricePrecision int8, volumePrecision int8, min
 	}
 }
 
+// MakeOrderConstraintsWithOverride is a factory method for OrderConstraints, oc is not a pointer because we want a copy since we modify it
+func MakeOrderConstraintsWithOverride(oc OrderConstraints, override *OrderConstraintsOverride) *OrderConstraints {
+	if override.PricePrecision != nil {
+		oc.PricePrecision = *override.PricePrecision
+	}
+	if override.VolumePrecision != nil {
+		oc.VolumePrecision = *override.VolumePrecision
+	}
+	if override.MinBaseVolume != nil {
+		oc.MinBaseVolume = *override.MinBaseVolume
+	}
+	if override.MinQuoteVolume != nil {
+		oc.MinQuoteVolume = *override.MinQuoteVolume
+	}
+	return &oc
+}
+
+// MakeOrderConstraintsFromOverride is a factory method to convert an OrderConstraintsOverride to an OrderConstraints
+func MakeOrderConstraintsFromOverride(override *OrderConstraintsOverride) *OrderConstraints {
+	return MakeOrderConstraintsWithOverride(OrderConstraints{}, override)
+}
+
 // OrderConstraints describes constraints when placing orders on an excahnge
 func (o *OrderConstraints) String() string {
 	minQuoteVolumeStr := nilString
@@ -314,4 +336,43 @@ func (o *OrderConstraints) String() string {
 
 	return fmt.Sprintf("OrderConstraints[PricePrecision: %d, VolumePrecision: %d, MinBaseVolume: %s, MinQuoteVolume: %s]",
 		o.PricePrecision, o.VolumePrecision, o.MinBaseVolume.AsString(), minQuoteVolumeStr)
+}
+
+// OrderConstraintsOverride describes an override for an OrderConstraint
+type OrderConstraintsOverride struct {
+	PricePrecision  *int8
+	VolumePrecision *int8
+	MinBaseVolume   *Number
+	MinQuoteVolume  **Number
+}
+
+// MakeOrderConstraintsOverride is a factory method for OrderConstraintsOverride
+func MakeOrderConstraintsOverride(oc *OrderConstraints) *OrderConstraintsOverride {
+	return &OrderConstraintsOverride{
+		PricePrecision:  &oc.PricePrecision,
+		VolumePrecision: &oc.VolumePrecision,
+		MinBaseVolume:   &oc.MinBaseVolume,
+		MinQuoteVolume:  &oc.MinQuoteVolume,
+	}
+}
+
+// IsComplete returns true if the override contains all values
+func (override *OrderConstraintsOverride) IsComplete() bool {
+	if override.PricePrecision == nil {
+		return false
+	}
+
+	if override.VolumePrecision == nil {
+		return false
+	}
+
+	if override.MinBaseVolume == nil {
+		return false
+	}
+
+	if override.MinQuoteVolume == nil {
+		return false
+	}
+
+	return true
 }

--- a/model/orderbook.go
+++ b/model/orderbook.go
@@ -346,8 +346,23 @@ type OrderConstraintsOverride struct {
 	MinQuoteVolume  **Number
 }
 
-// MakeOrderConstraintsOverride is a factory method for OrderConstraintsOverride
-func MakeOrderConstraintsOverride(oc *OrderConstraints) *OrderConstraintsOverride {
+// MakeOrderConstraintsOverride is a factory method
+func MakeOrderConstraintsOverride(
+	pricePrecision *int8,
+	volumePrecision *int8,
+	minBaseVolume *Number,
+	minQuoteVolume **Number,
+) *OrderConstraintsOverride {
+	return &OrderConstraintsOverride{
+		PricePrecision:  pricePrecision,
+		VolumePrecision: volumePrecision,
+		MinBaseVolume:   minBaseVolume,
+		MinQuoteVolume:  minQuoteVolume,
+	}
+}
+
+// MakeOrderConstraintsOverrideFromConstraints is a factory method for OrderConstraintsOverride
+func MakeOrderConstraintsOverrideFromConstraints(oc *OrderConstraints) *OrderConstraintsOverride {
 	return &OrderConstraintsOverride{
 		PricePrecision:  &oc.PricePrecision,
 		VolumePrecision: &oc.VolumePrecision,
@@ -375,4 +390,23 @@ func (override *OrderConstraintsOverride) IsComplete() bool {
 	}
 
 	return true
+}
+
+// Augment only updates values if updates are non-nil
+func (override *OrderConstraintsOverride) Augment(updates *OrderConstraintsOverride) {
+	if updates.PricePrecision != nil {
+		override.PricePrecision = updates.PricePrecision
+	}
+
+	if updates.VolumePrecision != nil {
+		override.VolumePrecision = updates.VolumePrecision
+	}
+
+	if updates.MinBaseVolume != nil {
+		override.MinBaseVolume = updates.MinBaseVolume
+	}
+
+	if updates.MinQuoteVolume != nil {
+		override.MinQuoteVolume = updates.MinQuoteVolume
+	}
 }

--- a/plugins/batchedExchange.go
+++ b/plugins/batchedExchange.go
@@ -154,6 +154,11 @@ func (b BatchedExchange) GetOrderConstraints(pair *model.TradingPair) *model.Ord
 	return b.inner.GetOrderConstraints(pair)
 }
 
+// OverrideOrderConstraints impl, can partially override values for specific pairs
+func (b BatchedExchange) OverrideOrderConstraints(pair *model.TradingPair, override *model.OrderConstraintsOverride) {
+	b.inner.OverrideOrderConstraints(pair, override)
+}
+
 // GetOrderBook impl
 func (b BatchedExchange) GetOrderBook(pair *model.TradingPair, maxCount int32) (*model.OrderBook, error) {
 	return b.inner.GetOrderBook(pair, maxCount)

--- a/plugins/batchedExchange.go
+++ b/plugins/batchedExchange.go
@@ -198,12 +198,6 @@ func (b BatchedExchange) SubmitOps(ops []build.TransactionMutator, asyncCallback
 		return nil
 	}
 
-	pair := &model.TradingPair{
-		Base:  model.FromHorizonAsset(b.baseAsset),
-		Quote: model.FromHorizonAsset(b.quoteAsset),
-	}
-	log.Printf("order constraints for trading pair %s: %s", pair, b.inner.GetOrderConstraints(pair))
-
 	results := []submitResult{}
 	numProcessed := 0
 	for _, c := range b.commands {

--- a/plugins/ccxtExchange.go
+++ b/plugins/ccxtExchange.go
@@ -20,11 +20,11 @@ var _ api.Exchange = ccxtExchange{}
 
 // ccxtExchange is the implementation for the CCXT REST library that supports many exchanges (https://github.com/franz-see/ccxt-rest, https://github.com/ccxt/ccxt/)
 type ccxtExchange struct {
-	assetConverter   *model.AssetConverter
-	delimiter        string
-	orderConstraints map[model.TradingPair]model.OrderConstraints
-	api              *sdk.Ccxt
-	simMode          bool
+	assetConverter     *model.AssetConverter
+	delimiter          string
+	ocOverridesHandler *OrderConstraintsOverridesHandler
+	api                *sdk.Ccxt
+	simMode            bool
 }
 
 // makeCcxtExchange is a factory method to make an exchange using the CCXT interface
@@ -47,16 +47,17 @@ func makeCcxtExchange(
 		return nil, fmt.Errorf("error making a ccxt exchange: %s", e)
 	}
 
-	if orderConstraintOverrides == nil {
-		orderConstraintOverrides = map[model.TradingPair]model.OrderConstraints{}
+	ocOverridesHandler := MakeEmptyOrderConstraintsOverridesHandler()
+	if orderConstraintOverrides != nil {
+		ocOverridesHandler = MakeOrderConstraintsOverridesHandler(orderConstraintOverrides)
 	}
 
 	return ccxtExchange{
-		assetConverter:   model.CcxtAssetConverter,
-		delimiter:        "/",
-		orderConstraints: orderConstraintOverrides,
-		api:              c,
-		simMode:          simMode,
+		assetConverter:     model.CcxtAssetConverter,
+		delimiter:          "/",
+		ocOverridesHandler: ocOverridesHandler,
+		api:                c,
+		simMode:            simMode,
 	}, nil
 }
 
@@ -99,10 +100,6 @@ func (c ccxtExchange) GetAssetConverter() *model.AssetConverter {
 
 // GetOrderConstraints impl
 func (c ccxtExchange) GetOrderConstraints(pair *model.TradingPair) *model.OrderConstraints {
-	if oc, ok := c.orderConstraints[*pair]; ok {
-		return &oc
-	}
-
 	pairString, e := pair.ToString(c.assetConverter, c.delimiter)
 	if e != nil {
 		// this should never really panic because we would have converted this trading pair to a string previously
@@ -114,12 +111,14 @@ func (c ccxtExchange) GetOrderConstraints(pair *model.TradingPair) *model.OrderC
 	if ccxtMarket == nil {
 		panic(fmt.Errorf("CCXT does not have precision and limit data for the passed in market: %s", pairString))
 	}
-	oc := *model.MakeOrderConstraintsWithCost(ccxtMarket.Precision.Price, ccxtMarket.Precision.Amount, ccxtMarket.Limits.Amount.Min, ccxtMarket.Limits.Cost.Min)
+	oc := model.MakeOrderConstraintsWithCost(ccxtMarket.Precision.Price, ccxtMarket.Precision.Amount, ccxtMarket.Limits.Amount.Min, ccxtMarket.Limits.Cost.Min)
 
-	// cache it before returning
-	c.orderConstraints[*pair] = oc
+	return c.ocOverridesHandler.Apply(pair, oc)
+}
 
-	return &oc
+// OverrideOrderConstraints impl, can partially override values for specific pairs
+func (c ccxtExchange) OverrideOrderConstraints(pair *model.TradingPair, override *model.OrderConstraintsOverride) {
+	c.ocOverridesHandler.Set(pair, override)
 }
 
 // GetAccountBalances impl

--- a/plugins/ccxtExchange.go
+++ b/plugins/ccxtExchange.go
@@ -118,7 +118,7 @@ func (c ccxtExchange) GetOrderConstraints(pair *model.TradingPair) *model.OrderC
 
 // OverrideOrderConstraints impl, can partially override values for specific pairs
 func (c ccxtExchange) OverrideOrderConstraints(pair *model.TradingPair, override *model.OrderConstraintsOverride) {
-	c.ocOverridesHandler.Set(pair, override)
+	c.ocOverridesHandler.Upsert(pair, override)
 }
 
 // GetAccountBalances impl

--- a/plugins/krakenExchange.go
+++ b/plugins/krakenExchange.go
@@ -29,6 +29,7 @@ type krakenExchange struct {
 	apis                     []*krakenapi.KrakenApi
 	apiNextIndex             uint8
 	delimiter                string
+	ocOverridesHandler       *OrderConstraintsOverridesHandler
 	withdrawKeys             asset2Address2Key
 	isSimulated              bool // will simulate add and cancel orders if this is true
 }
@@ -65,11 +66,12 @@ func makeKrakenExchange(apiKeys []api.ExchangeAPIKey, isSimulated bool) (api.Exc
 	return &krakenExchange{
 		assetConverter:           model.KrakenAssetConverter,
 		assetConverterOpenOrders: model.KrakenAssetConverterOpenOrders,
-		apis:         krakenAPIs,
-		apiNextIndex: 0,
-		delimiter:    "",
-		withdrawKeys: asset2Address2Key{},
-		isSimulated:  isSimulated,
+		apis:               krakenAPIs,
+		apiNextIndex:       0,
+		delimiter:          "",
+		ocOverridesHandler: MakeEmptyOrderConstraintsOverridesHandler(),
+		withdrawKeys:       asset2Address2Key{},
+		isSimulated:        isSimulated,
 	}, nil
 }
 
@@ -194,11 +196,21 @@ func getFieldValue(object krakenapi.BalanceResponse, fieldName string) float64 {
 
 // GetOrderConstraints impl
 func (k *krakenExchange) GetOrderConstraints(pair *model.TradingPair) *model.OrderConstraints {
-	constraints, ok := krakenPrecisionMatrix[*pair]
-	if !ok {
-		panic(fmt.Sprintf("krakenExchange could not find orderConstraints for trading pair %v. Try using the \"ccxt-kraken\" integration instead.", pair))
+	oc, ok := krakenPrecisionMatrix[*pair]
+	if ok {
+		return k.ocOverridesHandler.Apply(pair, &oc)
 	}
-	return &constraints
+
+	if k.ocOverridesHandler.IsCompletelyOverriden(pair) {
+		override := k.ocOverridesHandler.Get(pair)
+		return model.MakeOrderConstraintsFromOverride(override)
+	}
+	panic(fmt.Sprintf("krakenExchange could not find orderConstraints for trading pair %v. Try using the \"ccxt-kraken\" integration instead.", pair))
+}
+
+// OverrideOrderConstraints impl, can partially override values for specific pairs
+func (k *krakenExchange) OverrideOrderConstraints(pair *model.TradingPair, override *model.OrderConstraintsOverride) {
+	k.ocOverridesHandler.Set(pair, override)
 }
 
 // GetAssetConverter impl.

--- a/plugins/krakenExchange.go
+++ b/plugins/krakenExchange.go
@@ -210,7 +210,7 @@ func (k *krakenExchange) GetOrderConstraints(pair *model.TradingPair) *model.Ord
 
 // OverrideOrderConstraints impl, can partially override values for specific pairs
 func (k *krakenExchange) OverrideOrderConstraints(pair *model.TradingPair, override *model.OrderConstraintsOverride) {
-	k.ocOverridesHandler.Set(pair, override)
+	k.ocOverridesHandler.Upsert(pair, override)
 }
 
 // GetAssetConverter impl.

--- a/plugins/krakenExchange_test.go
+++ b/plugins/krakenExchange_test.go
@@ -16,11 +16,12 @@ import (
 var testKrakenExchange api.Exchange = &krakenExchange{
 	assetConverter:           model.KrakenAssetConverter,
 	assetConverterOpenOrders: model.KrakenAssetConverterOpenOrders,
-	apis:         []*krakenapi.KrakenApi{krakenapi.New("", "")},
-	apiNextIndex: 0,
-	delimiter:    "",
-	withdrawKeys: asset2Address2Key{},
-	isSimulated:  true,
+	apis:               []*krakenapi.KrakenApi{krakenapi.New("", "")},
+	apiNextIndex:       0,
+	delimiter:          "",
+	ocOverridesHandler: MakeEmptyOrderConstraintsOverridesHandler(),
+	withdrawKeys:       asset2Address2Key{},
+	isSimulated:        true,
 }
 
 func TestGetTickerPrice(t *testing.T) {

--- a/plugins/mirrorStrategy.go
+++ b/plugins/mirrorStrategy.go
@@ -104,8 +104,8 @@ func makeMirrorStrategy(sdex *SDEX, ieif *IEIF, pair *model.TradingPair, baseAss
 			return nil, e
 		}
 
-		if config.MinBaseVolumeOverride != nil && *config.MinBaseVolumeOverride == 0.0 {
-			return nil, fmt.Errorf("need to specify non-zero MIN_BASE_VOLUME_OVERRIDE config param in mirror strategy config file")
+		if config.MinBaseVolumeOverride != nil && *config.MinBaseVolumeOverride <= 0.0 {
+			return nil, fmt.Errorf("need to specify positive MIN_BASE_VOLUME_OVERRIDE config param in mirror strategy config file")
 		}
 		if config.VolumePrecisionOverride != nil && *config.VolumePrecisionOverride < 0 {
 			return nil, fmt.Errorf("need to specify non-negative VOLUME_PRECISION_OVERRIDE config param in mirror strategy config file")

--- a/plugins/mirrorStrategy.go
+++ b/plugins/mirrorStrategy.go
@@ -46,7 +46,10 @@ type mirrorConfig struct {
 // String impl.
 func (c mirrorConfig) String() string {
 	return utils.StructString(c, map[string]func(interface{}) interface{}{
-		"EXCHANGE_API_KEYS": utils.Hide,
+		"EXCHANGE_API_KEYS":         utils.Hide,
+		"MIN_BASE_VOLUME_OVERRIDE":  utils.UnwrapFloat64Pointer,
+		"VOLUME_PRECISION_OVERRIDE": utils.UnwrapInt8Pointer,
+		"PRICE_PRECISION_OVERRIDE":  utils.UnwrapInt8Pointer,
 	})
 }
 

--- a/plugins/mirrorStrategy.go
+++ b/plugins/mirrorStrategy.go
@@ -36,9 +36,9 @@ type mirrorConfig struct {
 	OrderbookDepth          int32               `valid:"-" toml:"ORDERBOOK_DEPTH"`
 	VolumeDivideBy          float64             `valid:"-" toml:"VOLUME_DIVIDE_BY"`
 	PerLevelSpread          float64             `valid:"-" toml:"PER_LEVEL_SPREAD"`
-	MinBaseVolumeOverride   *float64            `valid:"-" toml:"MIN_BASE_VOLUME_OVERRIDE"`
-	VolumePrecisionOverride *int8               `valid:"-" toml:"VOLUME_PRECISION_OVERRIDE"`
 	PricePrecisionOverride  *int8               `valid:"-" toml:"PRICE_PRECISION_OVERRIDE"`
+	VolumePrecisionOverride *int8               `valid:"-" toml:"VOLUME_PRECISION_OVERRIDE"`
+	MinBaseVolumeOverride   *float64            `valid:"-" toml:"MIN_BASE_VOLUME_OVERRIDE"`
 	OffsetTrades            bool                `valid:"-" toml:"OFFSET_TRADES"`
 	ExchangeAPIKeys         exchangeAPIKeysToml `valid:"-" toml:"EXCHANGE_API_KEYS"`
 }
@@ -47,9 +47,9 @@ type mirrorConfig struct {
 func (c mirrorConfig) String() string {
 	return utils.StructString(c, map[string]func(interface{}) interface{}{
 		"EXCHANGE_API_KEYS":         utils.Hide,
-		"MIN_BASE_VOLUME_OVERRIDE":  utils.UnwrapFloat64Pointer,
-		"VOLUME_PRECISION_OVERRIDE": utils.UnwrapInt8Pointer,
 		"PRICE_PRECISION_OVERRIDE":  utils.UnwrapInt8Pointer,
+		"VOLUME_PRECISION_OVERRIDE": utils.UnwrapInt8Pointer,
+		"MIN_BASE_VOLUME_OVERRIDE":  utils.UnwrapFloat64Pointer,
 	})
 }
 

--- a/plugins/orderConstraintsOverridesHandler.go
+++ b/plugins/orderConstraintsOverridesHandler.go
@@ -1,0 +1,55 @@
+package plugins
+
+import "github.com/stellar/kelp/model"
+
+// OrderConstraintsOverridesHandler knows how to capture overrides and apply them onto OrderConstraints
+type OrderConstraintsOverridesHandler struct {
+	overrides map[string]*model.OrderConstraintsOverride
+}
+
+// MakeEmptyOrderConstraintsOverridesHandler is a factory method
+func MakeEmptyOrderConstraintsOverridesHandler() *OrderConstraintsOverridesHandler {
+	return &OrderConstraintsOverridesHandler{
+		overrides: map[string]*model.OrderConstraintsOverride{},
+	}
+}
+
+// MakeOrderConstraintsOverridesHandler is a factory method
+func MakeOrderConstraintsOverridesHandler(inputs map[model.TradingPair]model.OrderConstraints) *OrderConstraintsOverridesHandler {
+	overrides := map[string]*model.OrderConstraintsOverride{}
+	for p, oc := range inputs {
+		overrides[p.String()] = model.MakeOrderConstraintsOverride(&oc)
+	}
+
+	return &OrderConstraintsOverridesHandler{
+		overrides: overrides,
+	}
+}
+
+// Apply creates a new order constraints after checking for any existing overrides
+func (ocHandler *OrderConstraintsOverridesHandler) Apply(pair *model.TradingPair, oc *model.OrderConstraints) *model.OrderConstraints {
+	override, has := ocHandler.overrides[pair.String()]
+	if !has {
+		return oc
+	}
+	return model.MakeOrderConstraintsWithOverride(*oc, override)
+}
+
+// Get impl, panics if the override does not exist
+func (ocHandler *OrderConstraintsOverridesHandler) Get(pair *model.TradingPair) *model.OrderConstraintsOverride {
+	return ocHandler.overrides[pair.String()]
+}
+
+// Set allows you to set overrides to partially override values for specific pairs
+func (ocHandler *OrderConstraintsOverridesHandler) Set(pair *model.TradingPair, override *model.OrderConstraintsOverride) {
+	ocHandler.overrides[pair.String()] = override
+}
+
+// IsCompletelyOverriden returns true if the override exists and is complete for the given trading pair
+func (ocHandler *OrderConstraintsOverridesHandler) IsCompletelyOverriden(pair *model.TradingPair) bool {
+	override, has := ocHandler.overrides[pair.String()]
+	if !has {
+		return false
+	}
+	return override.IsComplete()
+}

--- a/plugins/sdex.go
+++ b/plugins/sdex.go
@@ -46,9 +46,10 @@ type SDEX struct {
 	tradingOnSdex                 bool
 
 	// uninitialized
-	seqNum       uint64
-	reloadSeqNum bool
-	ieif         *IEIF
+	seqNum             uint64
+	reloadSeqNum       bool
+	ieif               *IEIF
+	ocOverridesHandler *OrderConstraintsOverridesHandler
 }
 
 // enforce SDEX implements api.Constrainable
@@ -93,11 +94,12 @@ func MakeSDEX(
 		threadTracker:                 threadTracker,
 		operationalBuffer:             operationalBuffer,
 		operationalBufferNonNativePct: operationalBufferNonNativePct,
-		simMode:        simMode,
-		pair:           pair,
-		assetMap:       assetMap,
-		opFeeStroopsFn: opFeeStroopsFn,
-		tradingOnSdex:  exchangeShim == nil,
+		simMode:            simMode,
+		pair:               pair,
+		assetMap:           assetMap,
+		opFeeStroopsFn:     opFeeStroopsFn,
+		tradingOnSdex:      exchangeShim == nil,
+		ocOverridesHandler: MakeEmptyOrderConstraintsOverridesHandler(),
 	}
 
 	if exchangeShim == nil {
@@ -165,7 +167,12 @@ func (sdex *SDEX) incrementSeqNum() {
 
 // GetOrderConstraints impl
 func (sdex *SDEX) GetOrderConstraints(pair *model.TradingPair) *model.OrderConstraints {
-	return sdexOrderConstraints
+	return sdex.ocOverridesHandler.Apply(pair, sdexOrderConstraints)
+}
+
+// OverrideOrderConstraints impl, can partially override values for specific pairs
+func (sdex *SDEX) OverrideOrderConstraints(pair *model.TradingPair, override *model.OrderConstraintsOverride) {
+	sdex.ocOverridesHandler.Set(pair, override)
 }
 
 // DeleteAllOffers is a helper that accumulates delete operations for the passed in offers

--- a/plugins/sdex.go
+++ b/plugins/sdex.go
@@ -172,7 +172,7 @@ func (sdex *SDEX) GetOrderConstraints(pair *model.TradingPair) *model.OrderConst
 
 // OverrideOrderConstraints impl, can partially override values for specific pairs
 func (sdex *SDEX) OverrideOrderConstraints(pair *model.TradingPair, override *model.OrderConstraintsOverride) {
-	sdex.ocOverridesHandler.Set(pair, override)
+	sdex.ocOverridesHandler.Upsert(pair, override)
 }
 
 // DeleteAllOffers is a helper that accumulates delete operations for the passed in offers

--- a/support/utils/configs.go
+++ b/support/utils/configs.go
@@ -79,3 +79,21 @@ func passthrough(i interface{}) interface{} {
 func Hide(i interface{}) interface{} {
 	return ""
 }
+
+// UnwrapFloat64Pointer unwraps a float64 pointer
+func UnwrapFloat64Pointer(i interface{}) interface{} {
+	p := i.(*float64)
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+// UnwrapInt8Pointer unwraps a int8 pointer
+func UnwrapInt8Pointer(i interface{}) interface{} {
+	p := i.(*int8)
+	if p == nil {
+		return ""
+	}
+	return *p
+}

--- a/trader/config.go
+++ b/trader/config.go
@@ -33,7 +33,7 @@ type BotConfig struct {
 	FillTrackerDeleteCyclesThreshold   int64      `valid:"-" toml:"FILL_TRACKER_DELETE_CYCLES_THRESHOLD"`
 	HorizonURL                         string     `valid:"-" toml:"HORIZON_URL"`
 	Fee                                *FeeConfig `valid:"-" toml:"FEE"`
-	MinCentralizedBaseVolumeOverride   *float64   `valid:"-" toml:"MIN_CENTRALIZED_BASE_VOLUME_OVERRIDE"`
+	CentralizedMinBaseVolumeOverride   *float64   `valid:"-" toml:"CENTRALIZED_MIN_BASE_VOLUME_OVERRIDE"`
 	CentralizedVolumePrecisionOverride *int8      `valid:"-" toml:"CENTRALIZED_VOLUME_PRECISION_OVERRIDE"`
 	CentralizedPricePrecisionOverride  *int8      `valid:"-" toml:"CENTRALIZED_PRICE_PRECISION_OVERRIDE"`
 	AlertType                          string     `valid:"-" toml:"ALERT_TYPE"`

--- a/trader/config.go
+++ b/trader/config.go
@@ -19,31 +19,33 @@ type FeeConfig struct {
 
 // BotConfig represents the configuration params for the bot
 type BotConfig struct {
-	SourceSecretSeed                 string     `valid:"-" toml:"SOURCE_SECRET_SEED"`
-	TradingSecretSeed                string     `valid:"-" toml:"TRADING_SECRET_SEED"`
-	AssetCodeA                       string     `valid:"-" toml:"ASSET_CODE_A"`
-	IssuerA                          string     `valid:"-" toml:"ISSUER_A"`
-	AssetCodeB                       string     `valid:"-" toml:"ASSET_CODE_B"`
-	IssuerB                          string     `valid:"-" toml:"ISSUER_B"`
-	TickIntervalSeconds              int32      `valid:"-" toml:"TICK_INTERVAL_SECONDS"`
-	MaxTickDelayMillis               int64      `valid:"-" toml:"MAX_TICK_DELAY_MILLIS"`
-	DeleteCyclesThreshold            int64      `valid:"-" toml:"DELETE_CYCLES_THRESHOLD"`
-	SubmitMode                       string     `valid:"-" toml:"SUBMIT_MODE"`
-	FillTrackerSleepMillis           uint32     `valid:"-" toml:"FILL_TRACKER_SLEEP_MILLIS"`
-	FillTrackerDeleteCyclesThreshold int64      `valid:"-" toml:"FILL_TRACKER_DELETE_CYCLES_THRESHOLD"`
-	HorizonURL                       string     `valid:"-" toml:"HORIZON_URL"`
-	Fee                              *FeeConfig `valid:"-" toml:"FEE"`
-	MinCentralizedBaseVolume         float64    `valid:"-" toml:"MIN_CENTRALIZED_BASE_VOLUME"`
-	AlertType                        string     `valid:"-" toml:"ALERT_TYPE"`
-	AlertAPIKey                      string     `valid:"-" toml:"ALERT_API_KEY"`
-	MonitoringPort                   uint16     `valid:"-" toml:"MONITORING_PORT"`
-	MonitoringTLSCert                string     `valid:"-" toml:"MONITORING_TLS_CERT"`
-	MonitoringTLSKey                 string     `valid:"-" toml:"MONITORING_TLS_KEY"`
-	GoogleClientID                   string     `valid:"-" toml:"GOOGLE_CLIENT_ID"`
-	GoogleClientSecret               string     `valid:"-" toml:"GOOGLE_CLIENT_SECRET"`
-	AcceptableEmails                 string     `valid:"-" toml:"ACCEPTABLE_GOOGLE_EMAILS"`
-	TradingExchange                  string     `valid:"-" toml:"TRADING_EXCHANGE"`
-	ExchangeAPIKeys                  []struct {
+	SourceSecretSeed                   string     `valid:"-" toml:"SOURCE_SECRET_SEED"`
+	TradingSecretSeed                  string     `valid:"-" toml:"TRADING_SECRET_SEED"`
+	AssetCodeA                         string     `valid:"-" toml:"ASSET_CODE_A"`
+	IssuerA                            string     `valid:"-" toml:"ISSUER_A"`
+	AssetCodeB                         string     `valid:"-" toml:"ASSET_CODE_B"`
+	IssuerB                            string     `valid:"-" toml:"ISSUER_B"`
+	TickIntervalSeconds                int32      `valid:"-" toml:"TICK_INTERVAL_SECONDS"`
+	MaxTickDelayMillis                 int64      `valid:"-" toml:"MAX_TICK_DELAY_MILLIS"`
+	DeleteCyclesThreshold              int64      `valid:"-" toml:"DELETE_CYCLES_THRESHOLD"`
+	SubmitMode                         string     `valid:"-" toml:"SUBMIT_MODE"`
+	FillTrackerSleepMillis             uint32     `valid:"-" toml:"FILL_TRACKER_SLEEP_MILLIS"`
+	FillTrackerDeleteCyclesThreshold   int64      `valid:"-" toml:"FILL_TRACKER_DELETE_CYCLES_THRESHOLD"`
+	HorizonURL                         string     `valid:"-" toml:"HORIZON_URL"`
+	Fee                                *FeeConfig `valid:"-" toml:"FEE"`
+	MinCentralizedBaseVolume           float64    `valid:"-" toml:"MIN_CENTRALIZED_BASE_VOLUME"`
+	CentralizedVolumePrecisionOverride *int8      `valid:"-" toml:"CENTRALIZED_VOLUME_PRECISION_OVERRIDE"`
+	CentralizedPricePrecisionOverride  *int8      `valid:"-" toml:"CENTRALIZED_PRICE_PRECISION_OVERRIDE"`
+	AlertType                          string     `valid:"-" toml:"ALERT_TYPE"`
+	AlertAPIKey                        string     `valid:"-" toml:"ALERT_API_KEY"`
+	MonitoringPort                     uint16     `valid:"-" toml:"MONITORING_PORT"`
+	MonitoringTLSCert                  string     `valid:"-" toml:"MONITORING_TLS_CERT"`
+	MonitoringTLSKey                   string     `valid:"-" toml:"MONITORING_TLS_KEY"`
+	GoogleClientID                     string     `valid:"-" toml:"GOOGLE_CLIENT_ID"`
+	GoogleClientSecret                 string     `valid:"-" toml:"GOOGLE_CLIENT_SECRET"`
+	AcceptableEmails                   string     `valid:"-" toml:"ACCEPTABLE_GOOGLE_EMAILS"`
+	TradingExchange                    string     `valid:"-" toml:"TRADING_EXCHANGE"`
+	ExchangeAPIKeys                    []struct {
 		Key    string `valid:"-" toml:"KEY"`
 		Secret string `valid:"-" toml:"SECRET"`
 	} `valid:"-" toml:"EXCHANGE_API_KEYS"`

--- a/trader/config.go
+++ b/trader/config.go
@@ -61,13 +61,16 @@ type BotConfig struct {
 // String impl.
 func (b BotConfig) String() string {
 	return utils.StructString(b, map[string]func(interface{}) interface{}{
-		"EXCHANGE_API_KEYS":        utils.Hide,
-		"SOURCE_SECRET_SEED":       utils.SecretKey2PublicKey,
-		"TRADING_SECRET_SEED":      utils.SecretKey2PublicKey,
-		"ALERT_API_KEY":            utils.Hide,
-		"GOOGLE_CLIENT_ID":         utils.Hide,
-		"GOOGLE_CLIENT_SECRET":     utils.Hide,
-		"ACCEPTABLE_GOOGLE_EMAILS": utils.Hide,
+		"EXCHANGE_API_KEYS":                     utils.Hide,
+		"SOURCE_SECRET_SEED":                    utils.SecretKey2PublicKey,
+		"TRADING_SECRET_SEED":                   utils.SecretKey2PublicKey,
+		"ALERT_API_KEY":                         utils.Hide,
+		"GOOGLE_CLIENT_ID":                      utils.Hide,
+		"GOOGLE_CLIENT_SECRET":                  utils.Hide,
+		"ACCEPTABLE_GOOGLE_EMAILS":              utils.Hide,
+		"CENTRALIZED_MIN_BASE_VOLUME_OVERRIDE":  utils.UnwrapFloat64Pointer,
+		"CENTRALIZED_VOLUME_PRECISION_OVERRIDE": utils.UnwrapInt8Pointer,
+		"CENTRALIZED_PRICE_PRECISION_OVERRIDE":  utils.UnwrapInt8Pointer,
 	})
 }
 

--- a/trader/config.go
+++ b/trader/config.go
@@ -33,9 +33,9 @@ type BotConfig struct {
 	FillTrackerDeleteCyclesThreshold   int64      `valid:"-" toml:"FILL_TRACKER_DELETE_CYCLES_THRESHOLD"`
 	HorizonURL                         string     `valid:"-" toml:"HORIZON_URL"`
 	Fee                                *FeeConfig `valid:"-" toml:"FEE"`
-	CentralizedMinBaseVolumeOverride   *float64   `valid:"-" toml:"CENTRALIZED_MIN_BASE_VOLUME_OVERRIDE"`
-	CentralizedVolumePrecisionOverride *int8      `valid:"-" toml:"CENTRALIZED_VOLUME_PRECISION_OVERRIDE"`
 	CentralizedPricePrecisionOverride  *int8      `valid:"-" toml:"CENTRALIZED_PRICE_PRECISION_OVERRIDE"`
+	CentralizedVolumePrecisionOverride *int8      `valid:"-" toml:"CENTRALIZED_VOLUME_PRECISION_OVERRIDE"`
+	CentralizedMinBaseVolumeOverride   *float64   `valid:"-" toml:"CENTRALIZED_MIN_BASE_VOLUME_OVERRIDE"`
 	AlertType                          string     `valid:"-" toml:"ALERT_TYPE"`
 	AlertAPIKey                        string     `valid:"-" toml:"ALERT_API_KEY"`
 	MonitoringPort                     uint16     `valid:"-" toml:"MONITORING_PORT"`
@@ -68,9 +68,9 @@ func (b BotConfig) String() string {
 		"GOOGLE_CLIENT_ID":                      utils.Hide,
 		"GOOGLE_CLIENT_SECRET":                  utils.Hide,
 		"ACCEPTABLE_GOOGLE_EMAILS":              utils.Hide,
-		"CENTRALIZED_MIN_BASE_VOLUME_OVERRIDE":  utils.UnwrapFloat64Pointer,
-		"CENTRALIZED_VOLUME_PRECISION_OVERRIDE": utils.UnwrapInt8Pointer,
 		"CENTRALIZED_PRICE_PRECISION_OVERRIDE":  utils.UnwrapInt8Pointer,
+		"CENTRALIZED_VOLUME_PRECISION_OVERRIDE": utils.UnwrapInt8Pointer,
+		"CENTRALIZED_MIN_BASE_VOLUME_OVERRIDE":  utils.UnwrapFloat64Pointer,
 	})
 }
 

--- a/trader/config.go
+++ b/trader/config.go
@@ -36,6 +36,7 @@ type BotConfig struct {
 	CentralizedPricePrecisionOverride  *int8      `valid:"-" toml:"CENTRALIZED_PRICE_PRECISION_OVERRIDE"`
 	CentralizedVolumePrecisionOverride *int8      `valid:"-" toml:"CENTRALIZED_VOLUME_PRECISION_OVERRIDE"`
 	CentralizedMinBaseVolumeOverride   *float64   `valid:"-" toml:"CENTRALIZED_MIN_BASE_VOLUME_OVERRIDE"`
+	CentralizedMinQuoteVolumeOverride  *float64   `valid:"-" toml:"CENTRALIZED_MIN_QUOTE_VOLUME_OVERRIDE"`
 	AlertType                          string     `valid:"-" toml:"ALERT_TYPE"`
 	AlertAPIKey                        string     `valid:"-" toml:"ALERT_API_KEY"`
 	MonitoringPort                     uint16     `valid:"-" toml:"MONITORING_PORT"`
@@ -71,6 +72,7 @@ func (b BotConfig) String() string {
 		"CENTRALIZED_PRICE_PRECISION_OVERRIDE":  utils.UnwrapInt8Pointer,
 		"CENTRALIZED_VOLUME_PRECISION_OVERRIDE": utils.UnwrapInt8Pointer,
 		"CENTRALIZED_MIN_BASE_VOLUME_OVERRIDE":  utils.UnwrapFloat64Pointer,
+		"CENTRALIZED_MIN_QUOTE_VOLUME_OVERRIDE": utils.UnwrapFloat64Pointer,
 	})
 }
 

--- a/trader/config.go
+++ b/trader/config.go
@@ -33,7 +33,7 @@ type BotConfig struct {
 	FillTrackerDeleteCyclesThreshold   int64      `valid:"-" toml:"FILL_TRACKER_DELETE_CYCLES_THRESHOLD"`
 	HorizonURL                         string     `valid:"-" toml:"HORIZON_URL"`
 	Fee                                *FeeConfig `valid:"-" toml:"FEE"`
-	MinCentralizedBaseVolume           float64    `valid:"-" toml:"MIN_CENTRALIZED_BASE_VOLUME"`
+	MinCentralizedBaseVolumeOverride   *float64   `valid:"-" toml:"MIN_CENTRALIZED_BASE_VOLUME_OVERRIDE"`
 	CentralizedVolumePrecisionOverride *int8      `valid:"-" toml:"CENTRALIZED_VOLUME_PRECISION_OVERRIDE"`
 	CentralizedPricePrecisionOverride  *int8      `valid:"-" toml:"CENTRALIZED_PRICE_PRECISION_OVERRIDE"`
 	AlertType                          string     `valid:"-" toml:"ALERT_TYPE"`

--- a/trader/trader.go
+++ b/trader/trader.go
@@ -163,6 +163,12 @@ func (t *Trader) update() {
 	t.load()
 	t.loadExistingOffers()
 
+	pair := &model.TradingPair{
+		Base:  model.FromHorizonAsset(t.assetBase),
+		Quote: model.FromHorizonAsset(t.assetQuote),
+	}
+	log.Printf("orderConstraints for trading pair %s: %s", pair, t.exchangeShim.GetOrderConstraints(pair))
+
 	// TODO 2 streamline the request data instead of caching
 	// reset cache of balances for this update cycle to reduce redundant requests to calculate asset balances
 	t.sdex.IEIF().ResetCachedBalances()

--- a/trader/trader.go
+++ b/trader/trader.go
@@ -55,7 +55,6 @@ func MakeBot(
 	assetBase horizon.Asset,
 	assetQuote horizon.Asset,
 	tradingPair *model.TradingPair,
-	minBaseVolume *float64,
 	tradingAccount string,
 	sdex *plugins.SDEX,
 	exchangeShim api.ExchangeShim,
@@ -70,11 +69,7 @@ func MakeBot(
 ) *Trader {
 	submitFilters := []plugins.SubmitFilter{}
 
-	oc := exchangeShim.GetOrderConstraints(tradingPair)
-	if minBaseVolume != nil {
-		oc.MinBaseVolume = *model.NumberFromFloat(*minBaseVolume, oc.VolumePrecision)
-	}
-	orderConstraintsFilter := plugins.MakeFilterOrderConstraints(oc, assetBase, assetQuote)
+	orderConstraintsFilter := plugins.MakeFilterOrderConstraints(exchangeShim.GetOrderConstraints(tradingPair), assetBase, assetQuote)
 	submitFilters = append(submitFilters, orderConstraintsFilter)
 
 	sdexSubmitFilter := plugins.MakeFilterMakerMode(submitMode, exchangeShim, sdex, tradingPair)

--- a/trader/trader.go
+++ b/trader/trader.go
@@ -67,11 +67,9 @@ func MakeBot(
 	dataKey *model.BotKey,
 	alert api.Alert,
 ) *Trader {
-	submitFilters := []plugins.SubmitFilter{}
-
-	orderConstraintsFilter := plugins.MakeFilterOrderConstraints(exchangeShim.GetOrderConstraints(tradingPair), assetBase, assetQuote)
-	submitFilters = append(submitFilters, orderConstraintsFilter)
-
+	submitFilters := []plugins.SubmitFilter{
+		plugins.MakeFilterOrderConstraints(exchangeShim.GetOrderConstraints(tradingPair), assetBase, assetQuote)
+	}
 	sdexSubmitFilter := plugins.MakeFilterMakerMode(submitMode, exchangeShim, sdex, tradingPair)
 	if sdexSubmitFilter != nil {
 		submitFilters = append(submitFilters, sdexSubmitFilter)

--- a/trader/trader.go
+++ b/trader/trader.go
@@ -68,7 +68,7 @@ func MakeBot(
 	alert api.Alert,
 ) *Trader {
 	submitFilters := []plugins.SubmitFilter{
-		plugins.MakeFilterOrderConstraints(exchangeShim.GetOrderConstraints(tradingPair), assetBase, assetQuote)
+		plugins.MakeFilterOrderConstraints(exchangeShim.GetOrderConstraints(tradingPair), assetBase, assetQuote),
 	}
 	sdexSubmitFilter := plugins.MakeFilterMakerMode(submitMode, exchangeShim, sdex, tradingPair)
 	if sdexSubmitFilter != nil {


### PR DESCRIPTION
add override options to the config file.

renamed `MIN_CENTRALIZED_BASE_VOLUME` to `CENTRALIZED_MIN_BASE_VOLUME_OVERRIDE`