### PR TITLE
Build and test Kelp with Semaphore CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,56 @@
+version: v1.0
+name: First pipeline example
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: "Build"
+    task:
+      env_vars:
+        - name: APP_ENV
+          value: prod
+      jobs:
+      - name: Docker build
+        commands:
+          - checkout
+          - ls -1
+          - echo $APP_ENV
+          - echo "Docker build..."
+          - echo "done"
+  - name: "Smoke tests"
+    task:
+      jobs:
+      - name: Smoke
+        commands:
+          - checkout
+          - echo "make smoke"
+  - name: "Unit tests"
+    task:
+      jobs:
+      - name: RSpec
+        commands:
+          - checkout
+          - echo "make rspec"
+      - name: Lint code
+        commands:
+          - checkout
+          - echo "make lint"
+      - name: Check security
+        commands:
+          - checkout
+          - echo "make security"
+  - name: "Integration tests"
+    task:
+      jobs:
+      - name: Cucumber
+        commands:
+          - checkout
+          - echo "make cucumber"
+  - name: "Push Image"
+    task:
+      jobs:
+      - name: Push
+        commands:
+          - checkout
+          - echo "make docker.push"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -10,15 +10,25 @@ blocks:
     task:
       prologue:
         commands:
+          # Golang setup, required since we're building with Go versions < 1.11:
           - export "SEMAPHORE_GIT_DIR=$(go env GOPATH)/src/github.com/stellar/${SEMAPHORE_PROJECT_NAME}"
           - export "PATH=$(go env GOPATH)/bin:${PATH}"
           - mkdir -vp "${SEMAPHORE_GIT_DIR}" "$(go env GOPATH)/bin"
+
+          # Checking out the repo:
           - checkout
+
+          # Installing glide and deps:
           - curl https://glide.sh/get | sh
           - glide install
+
+          # Installing node.js 10.5:
           - nvm install 10.5 && nvm use 10.5
+
+          # Running CCXT:
           - docker run -p 3000:3000 -d franzsee/ccxt-rest:v0.0.4
       jobs:
+        # Run the test suite + try building Kelp with Go 1.10
         - name: Run package tests (1.10)
           commands:
             - sem-version go 1.10
@@ -29,7 +39,7 @@ blocks:
             - bash scripts/build.sh
             - ./bin/kelp version
 
-
+        # Run the test suite + try building Kelp with Go 1.11
         - name: Run package tests (1.11)
           commands:
             - sem-version go 1.11
@@ -40,7 +50,7 @@ blocks:
             - bash scripts/build.sh
             - ./bin/kelp version
 
-
+        # Run the test suite + try building Kelp with Go 1.12
         - name: Run package tests (1.12)
           commands:
             - sem-version go 1.12

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,56 +1,54 @@
 version: v1.0
-name: First pipeline example
+name: Kelp test and build pipeline
 agent:
   machine:
     type: e1-standard-2
     os_image: ubuntu1804
+
 blocks:
-  - name: "Build"
+  - name: "Test and build Kelp"
     task:
-      env_vars:
-        - name: APP_ENV
-          value: prod
+      prologue:
+        commands:
+          - export "SEMAPHORE_GIT_DIR=$(go env GOPATH)/src/github.com/stellar/${SEMAPHORE_PROJECT_NAME}"
+          - export "PATH=$(go env GOPATH)/bin:${PATH}"
+          - mkdir -vp "${SEMAPHORE_GIT_DIR}" "$(go env GOPATH)/bin"
+          - checkout
+          - curl https://glide.sh/get | sh
+          - glide install
+          - nvm install 10.5 && nvm use 10.5
+          - docker run -p 3000:3000 -d franzsee/ccxt-rest:v0.0.4
       jobs:
-      - name: Docker build
-        commands:
-          - checkout
-          - ls -1
-          - echo $APP_ENV
-          - echo "Docker build..."
-          - echo "done"
-  - name: "Smoke tests"
-    task:
-      jobs:
-      - name: Smoke
-        commands:
-          - checkout
-          - echo "make smoke"
-  - name: "Unit tests"
-    task:
-      jobs:
-      - name: RSpec
-        commands:
-          - checkout
-          - echo "make rspec"
-      - name: Lint code
-        commands:
-          - checkout
-          - echo "make lint"
-      - name: Check security
-        commands:
-          - checkout
-          - echo "make security"
-  - name: "Integration tests"
-    task:
-      jobs:
-      - name: Cucumber
-        commands:
-          - checkout
-          - echo "make cucumber"
-  - name: "Push Image"
-    task:
-      jobs:
-      - name: Push
-        commands:
-          - checkout
-          - echo "make docker.push"
+        - name: Run package tests (1.10)
+          commands:
+            - sem-version go 1.10
+            - go test -tags dev --short ./...
+        - name: Build Kelp (1.10)
+          commands:
+            - sem-version go 1.10
+            - bash scripts/build.sh
+            - ./bin/kelp version
+
+
+        - name: Run package tests (1.11)
+          commands:
+            - sem-version go 1.11
+            - go test -tags dev --short ./...
+        - name: Build Kelp (1.11)
+          commands:
+            - sem-version go 1.11
+            - bash scripts/build.sh
+            - ./bin/kelp version
+
+
+        - name: Run package tests (1.12)
+          commands:
+            - sem-version go 1.12
+            - go test -tags dev --short ./...
+
+        - name: Build Kelp (1.12)
+          commands:
+            - sem-version go 1.12
+            - bash scripts/build.sh
+            - ./bin/kelp version
+


### PR DESCRIPTION
This PR aims to create an initial config for building and testing Kelp with Semaphore CI.

We're thinking about switching to Semaphore because it runs multiple builds in parallel, and it would greatly improve our workflow, especially in projects with many contributors such as the [Go monorepo](https://github.com/stellar/go).

**Note:** Once this PR gets merged, we'll need to do some setup on Semaphore to make sure it starts building stellar/kelp.