### PR TITLE
Add Circle CI support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,103 @@
+version: 2.1
+commands:
+  install_deps:
+    steps:
+      - checkout
+      - run:
+          name: Install glide
+          command: curl https://glide.sh/get | sh
+      - run:
+          name: Install dependencies using glide
+          command: glide install
+
+      - run:
+          name: Install nvm
+          command: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+      - run:
+          name: Use Node 10.5
+          command: echo 'export NVM_DIR=$HOME/.nvm' >> $BASH_ENV && echo 'source $NVM_DIR/nvm.sh' >> $BASH_ENV && source $BASH_ENV && nvm install 10.5 && nvm use 10.5
+
+  build_kelp:
+    steps:
+      - run:
+          name: Build Kelp
+          command: ./scripts/build.sh
+      - run:
+          name: Ensure build was successful
+          command: ./bin/kelp version
+
+
+jobs:
+  # test performs all package tests from Kelp
+  test_1_10:
+    working_directory: /go/src/github.com/stellar/kelp
+    docker:
+      - image: circleci/golang:1.10-node # primary image
+      - image: franzsee/ccxt-rest:v0.0.4
+        command: ["node", "/usr/local/bin/ccxt-rest"]
+
+    steps:
+      - install_deps
+      - run: go test -tags dev --short ./...
+
+  test_1_11:
+    working_directory: /go/src/github.com/stellar/kelp
+    docker:
+      - image: circleci/golang:1.11-node # primary image
+      - image: franzsee/ccxt-rest:v0.0.4
+        command: ["node", "/usr/local/bin/ccxt-rest"]
+
+    steps:
+      - install_deps
+      - run: go test -tags dev --short ./...
+
+  test_1_12:
+    working_directory: /go/src/github.com/stellar/kelp
+    docker:
+      - image: circleci/golang:1.12-node # primary image
+      - image: franzsee/ccxt-rest:v0.0.4
+        command: ["node", "/usr/local/bin/ccxt-rest"]
+
+    steps:
+      - install_deps
+      - run: go test -tags dev --short ./...
+
+
+  # build tries building Kelp
+  build_1_10:
+    working_directory: /go/src/github.com/stellar/kelp
+    docker:
+      - image: circleci/golang:1.10-node
+
+    steps:
+      - install_deps
+      - build_kelp
+
+  build_1_11:
+    working_directory: /go/src/github.com/stellar/kelp
+    docker:
+      - image: circleci/golang:1.11-node
+
+    steps:
+      - install_deps
+      - build_kelp
+
+  build_1_12:
+    working_directory: /go/src/github.com/stellar/kelp
+    docker:
+      - image: circleci/golang:1.12-node
+
+    steps:
+      - install_deps
+      - build_kelp
+
+workflows:
+  version: 2
+  build-and-test:
+    jobs:
+      - test_1_10
+      - test_1_11
+      - test_1_12
+      - build_1_10
+      - build_1_11
+      - build_1_12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,21 @@ commands:
   install_deps:
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v1-pkg-cache
+            - v1-node-cache
       - run:
           name: Install glide
           command: curl https://glide.sh/get | sh
       - run:
           name: Install dependencies using glide
           command: glide install
+
+      - save_cache:
+          key: v1-pkg-cache
+          paths:
+            - "/go/src/github.com/stellar/kelp/vendor"
 
       - run:
           name: Install nvm
@@ -31,6 +40,11 @@ commands:
       - run:
           name: Ensure build was successful
           command: ./bin/kelp version
+
+      - save_cache:
+          key: v1-node-cache
+          paths:
+            - "/go/src/github.com/stellar/kelp/gui/web/node_modules"
 
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,12 @@ commands:
           name: Use Node 10.5
           command: echo 'export NVM_DIR=$HOME/.nvm' >> $BASH_ENV && echo 'source $NVM_DIR/nvm.sh' >> $BASH_ENV && source $BASH_ENV && nvm install 10.5 && nvm use 10.5
 
+  test_kelp:
+    steps:
+      - run:
+          name: Run Kelp tests
+          command: go test -tags dev --short ./...
+
   build_kelp:
     steps:
       - run:
@@ -38,7 +44,7 @@ jobs:
 
     steps:
       - install_deps
-      - run: go test -tags dev --short ./...
+      - test_kelp
 
   test_1_11:
     working_directory: /go/src/github.com/stellar/kelp
@@ -49,7 +55,7 @@ jobs:
 
     steps:
       - install_deps
-      - run: go test -tags dev --short ./...
+      - test_kelp
 
   test_1_12:
     working_directory: /go/src/github.com/stellar/kelp
@@ -60,7 +66,7 @@ jobs:
 
     steps:
       - install_deps
-      - run: go test -tags dev --short ./...
+      - test_kelp
 
 
   # build tries building Kelp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,13 +19,6 @@ commands:
           paths:
             - "/go/src/github.com/stellar/kelp/vendor"
 
-      - run:
-          name: Install nvm
-          command: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
-      - run:
-          name: Use Node 10.5
-          command: echo 'export NVM_DIR=$HOME/.nvm' >> $BASH_ENV && echo 'source $NVM_DIR/nvm.sh' >> $BASH_ENV && source $BASH_ENV && nvm install 10.5 && nvm use 10.5
-
   test_kelp:
     steps:
       - run:
@@ -35,24 +28,28 @@ commands:
   build_kelp:
     steps:
       - run:
+          name: Install nvm
+          command: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+      - run:
+          name: Use Node 10.5
+          command: echo 'export NVM_DIR=$HOME/.nvm' >> $BASH_ENV && echo 'source $NVM_DIR/nvm.sh' >> $BASH_ENV && source $BASH_ENV && nvm install 10.5 && nvm use 10.5
+      - run:
           name: Build Kelp
           command: ./scripts/build.sh
-      - run:
-          name: Ensure build was successful
-          command: ./bin/kelp version
-
       - save_cache:
           key: v1-node-cache
           paths:
             - "/go/src/github.com/stellar/kelp/gui/web/node_modules"
-
+      - run:
+          name: Ensure build was successful
+          command: ./bin/kelp version
 
 jobs:
   # test performs all package tests from Kelp
   test_1_10:
     working_directory: /go/src/github.com/stellar/kelp
     docker:
-      - image: circleci/golang:1.10-node # primary image
+      - image: circleci/golang:1.10
       - image: franzsee/ccxt-rest:v0.0.4
         command: ["node", "/usr/local/bin/ccxt-rest"]
 
@@ -63,7 +60,7 @@ jobs:
   test_1_11:
     working_directory: /go/src/github.com/stellar/kelp
     docker:
-      - image: circleci/golang:1.11-node # primary image
+      - image: circleci/golang:1.11
       - image: franzsee/ccxt-rest:v0.0.4
         command: ["node", "/usr/local/bin/ccxt-rest"]
 
@@ -74,7 +71,7 @@ jobs:
   test_1_12:
     working_directory: /go/src/github.com/stellar/kelp
     docker:
-      - image: circleci/golang:1.12-node # primary image
+      - image: circleci/golang:1.12
       - image: franzsee/ccxt-rest:v0.0.4
         command: ["node", "/usr/local/bin/ccxt-rest"]
 


### PR DESCRIPTION
This PR adds the necessary configuration for building and testing Kelp through Circle CI.

All builds and tests, for each Go version, are run in parallel, and the `node_modules` and `vendor` directories (for node.js and Go, respectively) are cached.