### PR TITLE
Kelp: use new stellar go sdk

### DIFF
--- a/api/exchange.go
+++ b/api/exchange.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/model"
 )
 
@@ -224,8 +224,8 @@ type Balance struct {
 type ExchangeShim interface {
 	SubmitOps(ops []build.TransactionMutator, asyncCallback func(hash string, e error)) error
 	SubmitOpsSynch(ops []build.TransactionMutator, asyncCallback func(hash string, e error)) error // forced synchronous version of SubmitOps
-	GetBalanceHack(asset horizon.Asset) (*Balance, error)
-	LoadOffersHack() ([]horizon.Offer, error)
+	GetBalanceHack(asset hProtocol.Asset) (*Balance, error)
+	LoadOffersHack() ([]hProtocol.Offer, error)
 	Constrainable
 	OrderbookFetcher
 	FillTrackable

--- a/api/strategy.go
+++ b/api/strategy.go
@@ -2,24 +2,24 @@ package api
 
 import (
 	"github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/model"
 )
 
 // Strategy represents some logic for a bot to follow while doing market making
 type Strategy interface {
-	PruneExistingOffers(buyingAOffers []horizon.Offer, sellingAOffers []horizon.Offer) ([]build.TransactionMutator, []horizon.Offer, []horizon.Offer)
+	PruneExistingOffers(buyingAOffers []hProtocol.Offer, sellingAOffers []hProtocol.Offer) ([]build.TransactionMutator, []hProtocol.Offer, []hProtocol.Offer)
 	PreUpdate(maxAssetA float64, maxAssetB float64, trustA float64, trustB float64) error
-	UpdateWithOps(buyingAOffers []horizon.Offer, sellingAOffers []horizon.Offer) ([]build.TransactionMutator, error)
+	UpdateWithOps(buyingAOffers []hProtocol.Offer, sellingAOffers []hProtocol.Offer) ([]build.TransactionMutator, error)
 	PostUpdate() error
 	GetFillHandlers() ([]FillHandler, error)
 }
 
 // SideStrategy represents a strategy on a single side of the orderbook
 type SideStrategy interface {
-	PruneExistingOffers(offers []horizon.Offer) ([]build.TransactionMutator, []horizon.Offer)
+	PruneExistingOffers(offers []hProtocol.Offer) ([]build.TransactionMutator, []hProtocol.Offer)
 	PreUpdate(maxAssetA float64, maxAssetB float64, trustA float64, trustB float64) error
-	UpdateWithOps(offers []horizon.Offer) (ops []build.TransactionMutator, newTopOffer *model.Number, e error)
+	UpdateWithOps(offers []hProtocol.Offer) (ops []build.TransactionMutator, newTopOffer *model.Number, e error)
 	PostUpdate() error
 	GetFillHandlers() ([]FillHandler, error)
 }

--- a/cmd/terminate.go
+++ b/cmd/terminate.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/nikhilsaraf/go-tools/multithreading"
 	"github.com/spf13/cobra"
-	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/clients/horizonclient"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/config"
 	"github.com/stellar/kelp/model"
@@ -38,8 +38,8 @@ func init() {
 		log.Println("Started Terminator for account: ", *configFile.TradingAccount)
 
 		// --- start initialization of objects ----
-		client := &horizon.Client{
-			URL:        configFile.HorizonURL,
+		client := &horizonclient.Client{
+			HorizonURL: configFile.HorizonURL,
 			HTTP:       http.DefaultClient,
 			AppName:    "kelp",
 			AppVersion: version,

--- a/cmd/terminate.go
+++ b/cmd/terminate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nikhilsaraf/go-tools/multithreading"
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/config"
 	"github.com/stellar/kelp/model"
 	"github.com/stellar/kelp/plugins"
@@ -57,7 +58,7 @@ func init() {
 			-1, // not needed here
 			false,
 			nil, // not needed here
-			map[model.Asset]horizon.Asset{},
+			map[model.Asset]hProtocol.Asset{},
 			plugins.SdexFixedFeeFn(0),
 		)
 		terminator := terminator.MakeTerminator(client, sdex, *configFile.TradingAccount, configFile.TickIntervalSeconds, configFile.AllowInactiveMinutes)

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stellar/go/build"
 	"github.com/stellar/go/clients/horizon"
 	"github.com/stellar/go/clients/horizonclient"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/config"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
@@ -258,7 +259,7 @@ func makeExchangeShimSdex(
 		}
 	}
 
-	sdexAssetMap := map[model.Asset]horizon.Asset{
+	sdexAssetMap := map[model.Asset]hProtocol.Asset{
 		tradingPair.Base:  botConfig.AssetBase(),
 		tradingPair.Quote: botConfig.AssetQuote(),
 	}
@@ -294,8 +295,8 @@ func makeStrategy(
 	client *horizon.Client,
 	sdex *plugins.SDEX,
 	exchangeShim api.ExchangeShim,
-	assetBase horizon.Asset,
-	assetQuote horizon.Asset,
+	assetBase hProtocol.Asset,
+	assetQuote hProtocol.Asset,
 	ieif *plugins.IEIF,
 	tradingPair *model.TradingPair,
 	options inputs,

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -13,7 +13,6 @@ import (
 	"github.com/nikhilsaraf/go-tools/multithreading"
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
 	"github.com/stellar/go/clients/horizonclient"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/config"
@@ -150,7 +149,7 @@ func makeStartupMessage(options inputs) string {
 	return startupMessage
 }
 
-func makeFeeFn(l logger.Logger, botConfig trader.BotConfig, newClient *horizonclient.Client) plugins.OpFeeStroops {
+func makeFeeFn(l logger.Logger, botConfig trader.BotConfig, client *horizonclient.Client) plugins.OpFeeStroops {
 	if !botConfig.IsTradingSdex() {
 		return plugins.SdexFixedFeeFn(0)
 	}
@@ -159,7 +158,7 @@ func makeFeeFn(l logger.Logger, botConfig trader.BotConfig, newClient *horizoncl
 		botConfig.Fee.CapacityTrigger,
 		botConfig.Fee.Percentile,
 		botConfig.Fee.MaxOpFeeStroops,
-		newClient,
+		client,
 	)
 	if e != nil {
 		logger.Fatal(l, fmt.Errorf("could not set up feeFn correctly: %s", e))
@@ -195,8 +194,7 @@ func makeExchangeShimSdex(
 	l logger.Logger,
 	botConfig trader.BotConfig,
 	options inputs,
-	client *horizon.Client,
-	newClient *horizonclient.Client,
+	client *horizonclient.Client,
 	ieif *plugins.IEIF,
 	network build.Network,
 	threadTracker *multithreading.ThreadTracker,
@@ -263,7 +261,7 @@ func makeExchangeShimSdex(
 		tradingPair.Base:  botConfig.AssetBase(),
 		tradingPair.Quote: botConfig.AssetQuote(),
 	}
-	feeFn := makeFeeFn(l, botConfig, newClient)
+	feeFn := makeFeeFn(l, botConfig, client)
 	sdex := plugins.MakeSDEX(
 		client,
 		ieif,
@@ -292,7 +290,7 @@ func makeStrategy(
 	l logger.Logger,
 	network build.Network,
 	botConfig trader.BotConfig,
-	client *horizon.Client,
+	client *horizonclient.Client,
 	sdex *plugins.SDEX,
 	exchangeShim api.ExchangeShim,
 	assetBase hProtocol.Asset,
@@ -324,7 +322,7 @@ func makeStrategy(
 func makeBot(
 	l logger.Logger,
 	botConfig trader.BotConfig,
-	client *horizon.Client,
+	client *horizonclient.Client,
 	sdex *plugins.SDEX,
 	exchangeShim api.ExchangeShim,
 	ieif *plugins.IEIF,
@@ -397,20 +395,15 @@ func runTradeCmd(options inputs) {
 		Quote: model.Asset(utils.Asset2CodeString(assetQuote)),
 	}
 
-	client := &horizon.Client{
-		URL:  botConfig.HorizonURL,
-		HTTP: http.DefaultClient,
-	}
-	newClient := &horizonclient.Client{
+	client := &horizonclient.Client{
 		// TODO horizonclient.Client has a bug in it where it does not use "/" to separate the horizonURL from the fee_stats endpoint
+		// fixed in v1.2+
 		HorizonURL: botConfig.HorizonURL + "/",
 		HTTP:       http.DefaultClient,
 	}
 	if !*options.noHeaders {
 		client.AppName = "kelp"
 		client.AppVersion = version
-		newClient.AppName = "kelp"
-		newClient.AppVersion = version
 
 		p := prefs.Make(prefsFilename)
 		if p.FirstTime() {
@@ -439,7 +432,6 @@ func runTradeCmd(options inputs) {
 		botConfig,
 		options,
 		client,
-		newClient,
 		ieif,
 		network,
 		threadTracker,
@@ -560,7 +552,7 @@ func startFillTracking(
 	l logger.Logger,
 	strategy api.Strategy,
 	botConfig trader.BotConfig,
-	client *horizon.Client,
+	client *horizonclient.Client,
 	sdex *plugins.SDEX,
 	exchangeShim api.ExchangeShim,
 	tradingPair *model.TradingPair,
@@ -607,7 +599,7 @@ func startQueryServer(
 	strategyName string,
 	strategy api.Strategy,
 	botConfig trader.BotConfig,
-	client *horizon.Client,
+	client *horizonclient.Client,
 	sdex *plugins.SDEX,
 	exchangeShim api.ExchangeShim,
 	tradingPair *model.TradingPair,
@@ -643,14 +635,15 @@ func startQueryServer(
 	}()
 }
 
-func validateTrustlines(l logger.Logger, client *horizon.Client, botConfig *trader.BotConfig) {
+func validateTrustlines(l logger.Logger, client *horizonclient.Client, botConfig *trader.BotConfig) {
 	if !botConfig.IsTradingSdex() {
 		l.Info("no need to validate trustlines because we're not using SDEX as the trading exchange")
 		return
 	}
 
 	log.Printf("validating trustlines...\n")
-	account, e := client.LoadAccount(botConfig.TradingAccount())
+	accountReq := horizonclient.AccountRequest{AccountID: botConfig.TradingAccount()}
+	account, e := client.AccountDetail(accountReq)
 	if e != nil {
 		logger.Fatal(l, e)
 	}
@@ -679,7 +672,7 @@ func validateTrustlines(l logger.Logger, client *horizon.Client, botConfig *trad
 func deleteAllOffersAndExit(
 	l logger.Logger,
 	botConfig trader.BotConfig,
-	client *horizon.Client,
+	client *horizonclient.Client,
 	sdex *plugins.SDEX,
 	exchangeShim api.ExchangeShim,
 	threadTracker *multithreading.ThreadTracker,

--- a/gui/backend/autogenerate_bot.go
+++ b/gui/backend/autogenerate_bot.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stellar/kelp/support/kelpos"
 
 	"github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
 	"github.com/stellar/kelp/gui/model"
 	"github.com/stellar/kelp/plugins"
@@ -106,10 +106,11 @@ func (s *APIServer) setupAccount(address string, signer string, botName string) 
 	}
 	log.Printf("successfully funded account %s for bot '%s': %s\n", address, botName, fundResponse)
 
-	client := horizon.DefaultTestNetClient
+	client := horizonclient.DefaultTestNetClient
 	txn, e := build.Transaction(
 		build.SourceAccount{AddressOrSeed: address},
-		build.AutoSequence{SequenceProvider: client},
+		// to do fix with the new txnbuild
+		// build.AutoSequence{SequenceProvider: client},
 		build.TestNetwork,
 		build.Trust("COUPON", "GBMMZMK2DC4FFP4CAI6KCVNCQ7WLO5A7DQU7EC7WGHRDQBZB763X4OQI"),
 		build.Payment(
@@ -132,7 +133,7 @@ func (s *APIServer) setupAccount(address string, signer string, botName string) 
 		return fmt.Errorf("cannot convert trustline transaction to base64 for account %s for bot '%s': %s\n", address, botName, e)
 	}
 
-	resp, e := client.SubmitTransaction(txn64)
+	resp, e := client.SubmitTransactionXDR(txn64)
 	if e != nil {
 		return fmt.Errorf("error submitting change trust transaction for address %s for bot '%s': %s\n", address, botName, e)
 	}

--- a/model/assets.go
+++ b/model/assets.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/support/utils"
 )
 
@@ -173,7 +173,7 @@ var KrakenAssetConverterOpenOrders = makeAssetConverter(map[Asset]string{
 })
 
 // FromHorizonAsset is a factory method
-func FromHorizonAsset(hAsset horizon.Asset) Asset {
+func FromHorizonAsset(hAsset hProtocol.Asset) Asset {
 	if hAsset.Type == utils.Native {
 		return XLM
 	}

--- a/model/botKey.go
+++ b/model/botKey.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 )
 
 const botDataKeyPrefix = "b/"
@@ -30,7 +30,7 @@ func (b BotKey) String() string {
 }
 
 // MakeSortedBotKey makes a BotKey by sorting the passed in assets
-func MakeSortedBotKey(assetA horizon.Asset, assetB horizon.Asset) *BotKey {
+func MakeSortedBotKey(assetA hProtocol.Asset, assetB hProtocol.Asset) *BotKey {
 	var assetBaseCode, assetBaseIssuer, assetQuoteCode, assetQuoteIssuer string
 	if assetA.Type == native && assetB.Type == native {
 		log.Fatal("invalid asset types, both cannot be native")

--- a/plugins/balancedStrategy.go
+++ b/plugins/balancedStrategy.go
@@ -1,7 +1,7 @@
 package plugins
 
 import (
-	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
 	"github.com/stellar/kelp/support/utils"
@@ -34,8 +34,8 @@ func makeBalancedStrategy(
 	sdex *SDEX,
 	pair *model.TradingPair,
 	ieif *IEIF,
-	assetBase *horizon.Asset,
-	assetQuote *horizon.Asset,
+	assetBase *hProtocol.Asset,
+	assetQuote *hProtocol.Asset,
 	config *balancedConfig,
 ) api.Strategy {
 	orderConstraints := sdex.GetOrderConstraints(pair)

--- a/plugins/buysellStrategy.go
+++ b/plugins/buysellStrategy.go
@@ -3,7 +3,7 @@ package plugins
 import (
 	"fmt"
 
-	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
 	"github.com/stellar/kelp/support/utils"
@@ -63,8 +63,8 @@ func makeBuySellStrategy(
 	sdex *SDEX,
 	pair *model.TradingPair,
 	ieif *IEIF,
-	assetBase *horizon.Asset,
-	assetQuote *horizon.Asset,
+	assetBase *hProtocol.Asset,
+	assetQuote *hProtocol.Asset,
 	config *BuySellConfig,
 ) (api.Strategy, error) {
 	offsetSell := rateOffset{

--- a/plugins/composeStrategy.go
+++ b/plugins/composeStrategy.go
@@ -7,15 +7,15 @@ import (
 	"github.com/stellar/kelp/model"
 
 	"github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/kelp/support/utils"
 )
 
 // composeStrategy is a strategy that is composed of two sub-strategies
 type composeStrategy struct {
-	assetBase  *horizon.Asset
-	assetQuote *horizon.Asset
+	assetBase  *hProtocol.Asset
+	assetQuote *hProtocol.Asset
 	buyStrat   api.SideStrategy
 	sellStrat  api.SideStrategy
 }
@@ -25,8 +25,8 @@ var _ api.Strategy = &composeStrategy{}
 
 // makeComposeStrategy is a factory method for composeStrategy
 func makeComposeStrategy(
-	assetBase *horizon.Asset,
-	assetQuote *horizon.Asset,
+	assetBase *hProtocol.Asset,
+	assetQuote *hProtocol.Asset,
 	buyStrat api.SideStrategy,
 	sellStrat api.SideStrategy,
 ) api.Strategy {
@@ -39,7 +39,7 @@ func makeComposeStrategy(
 }
 
 // PruneExistingOffers impl
-func (s *composeStrategy) PruneExistingOffers(buyingAOffers []horizon.Offer, sellingAOffers []horizon.Offer) ([]build.TransactionMutator, []horizon.Offer, []horizon.Offer) {
+func (s *composeStrategy) PruneExistingOffers(buyingAOffers []hProtocol.Offer, sellingAOffers []hProtocol.Offer) ([]build.TransactionMutator, []hProtocol.Offer, []hProtocol.Offer) {
 	pruneOps1, newBuyingAOffers := s.buyStrat.PruneExistingOffers(buyingAOffers)
 	pruneOps2, newSellingAOffers := s.sellStrat.PruneExistingOffers(sellingAOffers)
 	pruneOps1 = append(pruneOps1, pruneOps2...)
@@ -69,8 +69,8 @@ func (s *composeStrategy) PreUpdate(maxAssetBase float64, maxAssetQuote float64,
 
 // UpdateWithOps impl
 func (s *composeStrategy) UpdateWithOps(
-	buyingAOffers []horizon.Offer,
-	sellingAOffers []horizon.Offer,
+	buyingAOffers []hProtocol.Offer,
+	sellingAOffers []hProtocol.Offer,
 ) ([]build.TransactionMutator, error) {
 	// buy side, flip newTopBuyPrice because it will be inverted from this parent strategy's context of base/quote
 	buyOps, newTopBuyPriceInverted, e1 := s.buyStrat.UpdateWithOps(buyingAOffers)

--- a/plugins/deleteSideStrategy.go
+++ b/plugins/deleteSideStrategy.go
@@ -4,7 +4,7 @@ import (
 	"log"
 
 	"github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
 )
@@ -12,8 +12,8 @@ import (
 // deleteSideStrategy is a sideStrategy to delete the orders for a given currency pair on one side of the orderbook
 type deleteSideStrategy struct {
 	sdex       *SDEX
-	assetBase  *horizon.Asset
-	assetQuote *horizon.Asset
+	assetBase  *hProtocol.Asset
+	assetQuote *hProtocol.Asset
 }
 
 // ensure it implements SideStrategy
@@ -22,8 +22,8 @@ var _ api.SideStrategy = &deleteSideStrategy{}
 // makeDeleteSideStrategy is a factory method for deleteSideStrategy
 func makeDeleteSideStrategy(
 	sdex *SDEX,
-	assetBase *horizon.Asset,
-	assetQuote *horizon.Asset,
+	assetBase *hProtocol.Asset,
+	assetQuote *hProtocol.Asset,
 ) api.SideStrategy {
 	return &deleteSideStrategy{
 		sdex:       sdex,
@@ -33,14 +33,14 @@ func makeDeleteSideStrategy(
 }
 
 // PruneExistingOffers impl
-func (s *deleteSideStrategy) PruneExistingOffers(offers []horizon.Offer) ([]build.TransactionMutator, []horizon.Offer) {
+func (s *deleteSideStrategy) PruneExistingOffers(offers []hProtocol.Offer) ([]build.TransactionMutator, []hProtocol.Offer) {
 	log.Printf("deleteSideStrategy: deleting %d offers\n", len(offers))
 	pruneOps := []build.TransactionMutator{}
 	for i := 0; i < len(offers); i++ {
 		pOp := s.sdex.DeleteOffer(offers[i])
 		pruneOps = append(pruneOps, &pOp)
 	}
-	return pruneOps, []horizon.Offer{}
+	return pruneOps, []hProtocol.Offer{}
 }
 
 // PreUpdate impl
@@ -49,7 +49,7 @@ func (s *deleteSideStrategy) PreUpdate(maxAssetBase float64, maxAssetQuote float
 }
 
 // UpdateWithOps impl
-func (s *deleteSideStrategy) UpdateWithOps(offers []horizon.Offer) (ops []build.TransactionMutator, newTopOffer *model.Number, e error) {
+func (s *deleteSideStrategy) UpdateWithOps(offers []hProtocol.Offer) (ops []build.TransactionMutator, newTopOffer *model.Number, e error) {
 	return []build.TransactionMutator{}, nil, nil
 }
 

--- a/plugins/deleteStrategy.go
+++ b/plugins/deleteStrategy.go
@@ -1,15 +1,15 @@
 package plugins
 
 import (
-	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/api"
 )
 
 // makeDeleteStrategy is a factory method
 func makeDeleteStrategy(
 	sdex *SDEX,
-	assetBase *horizon.Asset,
-	assetQuote *horizon.Asset,
+	assetBase *hProtocol.Asset,
+	assetQuote *hProtocol.Asset,
 ) api.Strategy {
 	return makeComposeStrategy(
 		assetBase,

--- a/plugins/factory.go
+++ b/plugins/factory.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/config"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
@@ -17,8 +17,8 @@ type strategyFactoryData struct {
 	sdex            *SDEX
 	ieif            *IEIF
 	tradingPair     *model.TradingPair
-	assetBase       *horizon.Asset
-	assetQuote      *horizon.Asset
+	assetBase       *hProtocol.Asset
+	assetQuote      *hProtocol.Asset
 	stratConfigPath string
 	simMode         bool
 }
@@ -114,8 +114,8 @@ func MakeStrategy(
 	sdex *SDEX,
 	ieif *IEIF,
 	tradingPair *model.TradingPair,
-	assetBase *horizon.Asset,
-	assetQuote *horizon.Asset,
+	assetBase *hProtocol.Asset,
+	assetQuote *hProtocol.Asset,
 	strategy string,
 	stratConfigPath string,
 	simMode bool,

--- a/plugins/makerModeFilter.go
+++ b/plugins/makerModeFilter.go
@@ -6,7 +6,7 @@ import (
 	"math"
 
 	"github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
 	"github.com/stellar/kelp/support/utils"
@@ -32,7 +32,7 @@ func MakeFilterMakerMode(submitMode api.SubmitMode, exchangeShim api.ExchangeShi
 
 var _ SubmitFilter = &makerModeFilter{}
 
-func (f *makerModeFilter) Apply(ops []build.TransactionMutator, sellingOffers []horizon.Offer, buyingOffers []horizon.Offer) ([]build.TransactionMutator, error) {
+func (f *makerModeFilter) Apply(ops []build.TransactionMutator, sellingOffers []hProtocol.Offer, buyingOffers []hProtocol.Offer) ([]build.TransactionMutator, error) {
 	ob, e := f.exchangeShim.GetOrderBook(f.tradingPair, 50)
 	if e != nil {
 		return nil, fmt.Errorf("could not fetch orderbook: %s", e)
@@ -56,7 +56,7 @@ func isNewLevel(lastPrice *model.Number, priceNumber *model.Number, isSell bool)
 	return false
 }
 
-func (f *makerModeFilter) collateOffers(traderOffers []horizon.Offer, isSell bool) ([]api.Level, error) {
+func (f *makerModeFilter) collateOffers(traderOffers []hProtocol.Offer, isSell bool) ([]api.Level, error) {
 	oc := f.exchangeShim.GetOrderConstraints(f.tradingPair)
 
 	levels := []api.Level{}
@@ -86,7 +86,7 @@ func (f *makerModeFilter) collateOffers(traderOffers []horizon.Offer, isSell boo
 	return levels, nil
 }
 
-func (f *makerModeFilter) topOrderPriceExcludingTrader(obSide []model.Order, traderOffers []horizon.Offer, isSell bool) (*model.Number, error) {
+func (f *makerModeFilter) topOrderPriceExcludingTrader(obSide []model.Order, traderOffers []hProtocol.Offer, isSell bool) (*model.Number, error) {
 	traderLevels, e := f.collateOffers(traderOffers, isSell)
 	if e != nil {
 		return nil, fmt.Errorf("unable to collate offers: %s", e)
@@ -112,8 +112,8 @@ func (f *makerModeFilter) topOrderPriceExcludingTrader(obSide []model.Order, tra
 func (f *makerModeFilter) filterOps(
 	ops []build.TransactionMutator,
 	ob *model.OrderBook,
-	sellingOffers []horizon.Offer,
-	buyingOffers []horizon.Offer,
+	sellingOffers []hProtocol.Offer,
+	buyingOffers []hProtocol.Offer,
 ) ([]build.TransactionMutator, error) {
 	baseAsset, quoteAsset, e := f.sdex.Assets()
 	if e != nil {
@@ -174,8 +174,8 @@ func (f *makerModeFilter) filterOps(
 }
 
 func (f *makerModeFilter) transformOfferMakerMode(
-	baseAsset horizon.Asset,
-	quoteAsset horizon.Asset,
+	baseAsset hProtocol.Asset,
+	quoteAsset hProtocol.Asset,
 	topBidPrice *model.Number,
 	topAskPrice *model.Number,
 	op *build.ManageOfferBuilder,

--- a/plugins/orderConstraintsFilter.go
+++ b/plugins/orderConstraintsFilter.go
@@ -6,15 +6,15 @@ import (
 	"math"
 
 	"github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/model"
 	"github.com/stellar/kelp/support/utils"
 )
 
 type orderConstraintsFilter struct {
 	oc         *model.OrderConstraints
-	baseAsset  horizon.Asset
-	quoteAsset horizon.Asset
+	baseAsset  hProtocol.Asset
+	quoteAsset hProtocol.Asset
 }
 
 var _ SubmitFilter = &orderConstraintsFilter{}
@@ -22,8 +22,8 @@ var _ SubmitFilter = &orderConstraintsFilter{}
 // MakeFilterOrderConstraints makes a submit filter based on the passed in orderConstraints
 func MakeFilterOrderConstraints(
 	oc *model.OrderConstraints,
-	baseAsset horizon.Asset,
-	quoteAsset horizon.Asset,
+	baseAsset hProtocol.Asset,
+	quoteAsset hProtocol.Asset,
 ) SubmitFilter {
 	return &orderConstraintsFilter{
 		oc:         oc,
@@ -35,8 +35,8 @@ func MakeFilterOrderConstraints(
 // Apply impl.
 func (f *orderConstraintsFilter) Apply(
 	ops []build.TransactionMutator,
-	sellingOffers []horizon.Offer,
-	buyingOffers []horizon.Offer,
+	sellingOffers []hProtocol.Offer,
+	buyingOffers []hProtocol.Offer,
 ) ([]build.TransactionMutator, error) {
 	numKeep := 0
 	numDropped := 0

--- a/plugins/priceFeed.go
+++ b/plugins/priceFeed.go
@@ -5,14 +5,14 @@ import (
 	"strings"
 
 	"github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
 )
 
 // privateSdexHack is a temporary hack struct for SDEX price feeds pending refactor
 type privateSdexHack struct {
-	API     *horizon.Client
+	API     *horizonclient.Client
 	Ieif    *IEIF
 	Network build.Network
 }
@@ -21,7 +21,7 @@ type privateSdexHack struct {
 var privateSdexHackVar *privateSdexHack
 
 // SetPrivateSdexHack sets the privateSdexHack variable which is temporary until the pending SDEX price feed refactor
-func SetPrivateSdexHack(api *horizon.Client, ieif *IEIF, network build.Network) error {
+func SetPrivateSdexHack(api *horizonclient.Client, ieif *IEIF, network build.Network) error {
 	if privateSdexHackVar != nil {
 		return fmt.Errorf("privateSdexHack is already set: %+v", privateSdexHackVar)
 	}

--- a/plugins/sdex.go
+++ b/plugins/sdex.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stellar/go/build"
 	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
 	"github.com/stellar/kelp/support/utils"
@@ -41,7 +42,7 @@ type SDEX struct {
 	operationalBufferNonNativePct float64
 	simMode                       bool
 	pair                          *model.TradingPair
-	assetMap                      map[model.Asset]horizon.Asset // this is needed until we fully address putting SDEX behind the Exchange interface
+	assetMap                      map[model.Asset]hProtocol.Asset // this is needed until we fully address putting SDEX behind the Exchange interface
 	opFeeStroopsFn                OpFeeStroops
 	tradingOnSdex                 bool
 
@@ -80,7 +81,7 @@ func MakeSDEX(
 	operationalBufferNonNativePct float64,
 	simMode bool,
 	pair *model.TradingPair,
-	assetMap map[model.Asset]horizon.Asset,
+	assetMap map[model.Asset]hProtocol.Asset,
 	opFeeStroopsFn OpFeeStroops,
 ) *SDEX {
 	sdex := &SDEX{
@@ -94,12 +95,12 @@ func MakeSDEX(
 		threadTracker:                 threadTracker,
 		operationalBuffer:             operationalBuffer,
 		operationalBufferNonNativePct: operationalBufferNonNativePct,
-		simMode:            simMode,
-		pair:               pair,
-		assetMap:           assetMap,
-		opFeeStroopsFn:     opFeeStroopsFn,
-		tradingOnSdex:      exchangeShim == nil,
-		ocOverridesHandler: MakeEmptyOrderConstraintsOverridesHandler(),
+		simMode:                       simMode,
+		pair:                          pair,
+		assetMap:                      assetMap,
+		opFeeStroopsFn:                opFeeStroopsFn,
+		tradingOnSdex:                 exchangeShim == nil,
+		ocOverridesHandler:            MakeEmptyOrderConstraintsOverridesHandler(),
 	}
 
 	if exchangeShim == nil {
@@ -129,8 +130,8 @@ func (sdex *SDEX) IEIF() *IEIF {
 func (sdex *SDEX) GetAccountBalances(assetList []interface{}) (map[interface{}]model.Number, error) {
 	m := map[interface{}]model.Number{}
 	for _, elem := range assetList {
-		var a horizon.Asset
-		if v, ok := elem.(horizon.Asset); ok {
+		var a hProtocol.Asset
+		if v, ok := elem.(hProtocol.Asset); ok {
 			a = v
 		} else {
 			return nil, fmt.Errorf("invalid type of asset passed in, only horizon.Asset accepted")
@@ -176,7 +177,7 @@ func (sdex *SDEX) OverrideOrderConstraints(pair *model.TradingPair, override *mo
 }
 
 // DeleteAllOffers is a helper that accumulates delete operations for the passed in offers
-func (sdex *SDEX) DeleteAllOffers(offers []horizon.Offer) []build.TransactionMutator {
+func (sdex *SDEX) DeleteAllOffers(offers []hProtocol.Offer) []build.TransactionMutator {
 	ops := []build.TransactionMutator{}
 	for _, offer := range offers {
 		op := sdex.DeleteOffer(offer)
@@ -186,7 +187,7 @@ func (sdex *SDEX) DeleteAllOffers(offers []horizon.Offer) []build.TransactionMut
 }
 
 // DeleteOffer returns the op that needs to be submitted to the network in order to delete the passed in offer
-func (sdex *SDEX) DeleteOffer(offer horizon.Offer) build.ManageOfferBuilder {
+func (sdex *SDEX) DeleteOffer(offer hProtocol.Offer) build.ManageOfferBuilder {
 	rate := build.Rate{
 		Selling: utils.Asset2Asset(offer.Selling),
 		Buying:  utils.Asset2Asset(offer.Buying),
@@ -200,17 +201,17 @@ func (sdex *SDEX) DeleteOffer(offer horizon.Offer) build.ManageOfferBuilder {
 }
 
 // ModifyBuyOffer modifies a buy offer
-func (sdex *SDEX) ModifyBuyOffer(offer horizon.Offer, price float64, amount float64, incrementalNativeAmountRaw float64) (*build.ManageOfferBuilder, error) {
+func (sdex *SDEX) ModifyBuyOffer(offer hProtocol.Offer, price float64, amount float64, incrementalNativeAmountRaw float64) (*build.ManageOfferBuilder, error) {
 	return sdex.ModifySellOffer(offer, 1/price, amount*price, incrementalNativeAmountRaw)
 }
 
 // ModifySellOffer modifies a sell offer
-func (sdex *SDEX) ModifySellOffer(offer horizon.Offer, price float64, amount float64, incrementalNativeAmountRaw float64) (*build.ManageOfferBuilder, error) {
+func (sdex *SDEX) ModifySellOffer(offer hProtocol.Offer, price float64, amount float64, incrementalNativeAmountRaw float64) (*build.ManageOfferBuilder, error) {
 	return sdex.createModifySellOffer(&offer, offer.Selling, offer.Buying, price, amount, incrementalNativeAmountRaw)
 }
 
 // CreateSellOffer creates a sell offer
-func (sdex *SDEX) CreateSellOffer(base horizon.Asset, counter horizon.Asset, price float64, amount float64, incrementalNativeAmountRaw float64) (*build.ManageOfferBuilder, error) {
+func (sdex *SDEX) CreateSellOffer(base hProtocol.Asset, counter hProtocol.Asset, price float64, amount float64, incrementalNativeAmountRaw float64) (*build.ManageOfferBuilder, error) {
 	return sdex.createModifySellOffer(nil, base, counter, price, amount, incrementalNativeAmountRaw)
 }
 
@@ -219,7 +220,7 @@ func (sdex *SDEX) minReserve(subentries int32) float64 {
 }
 
 // assetBalance returns asset balance, asset trust limit, reserve balance (zero for non-XLM), error
-func (sdex *SDEX) _assetBalance(asset horizon.Asset) (*api.Balance, error) {
+func (sdex *SDEX) _assetBalance(asset hProtocol.Asset) (*api.Balance, error) {
 	account, err := sdex.API.LoadAccount(sdex.TradingAccount)
 	if err != nil {
 		return nil, fmt.Errorf("error: unable to load account to fetch balance: %s", err)
@@ -255,17 +256,17 @@ func (sdex *SDEX) _assetBalance(asset horizon.Asset) (*api.Balance, error) {
 }
 
 // GetBalanceHack impl
-func (sdex *SDEX) GetBalanceHack(asset horizon.Asset) (*api.Balance, error) {
+func (sdex *SDEX) GetBalanceHack(asset hProtocol.Asset) (*api.Balance, error) {
 	b, e := sdex._assetBalance(asset)
 	return b, e
 }
 
 // LoadOffersHack impl
-func (sdex *SDEX) LoadOffersHack() ([]horizon.Offer, error) {
+func (sdex *SDEX) LoadOffersHack() ([]hProtocol.Offer, error) {
 	return sdex._loadOffers()
 }
 
-func (sdex *SDEX) _loadOffers() ([]horizon.Offer, error) {
+func (sdex *SDEX) _loadOffers() ([]hProtocol.Offer, error) {
 	return utils.LoadAllOffers(sdex.TradingAccount, sdex.API)
 }
 
@@ -284,7 +285,7 @@ func (sdex *SDEX) ComputeIncrementalNativeAmountRaw(isNewOffer bool) float64 {
 }
 
 // createModifySellOffer is the main method that handles the logic of creating or modifying an offer, note that all offers are treated as sell offers in Stellar
-func (sdex *SDEX) createModifySellOffer(offer *horizon.Offer, selling horizon.Asset, buying horizon.Asset, price float64, amount float64, incrementalNativeAmountRaw float64) (*build.ManageOfferBuilder, error) {
+func (sdex *SDEX) createModifySellOffer(offer *hProtocol.Offer, selling hProtocol.Asset, buying hProtocol.Asset, price float64, amount float64, incrementalNativeAmountRaw float64) (*build.ManageOfferBuilder, error) {
 	if price <= 0 {
 		return nil, fmt.Errorf("error: cannot create or modify offer, invalid price: %.8f", price)
 	}
@@ -409,7 +410,7 @@ func (sdex *SDEX) submitOps(ops []build.TransactionMutator, asyncCallback func(h
 }
 
 // CreateBuyOffer creates a buy offer
-func (sdex *SDEX) CreateBuyOffer(base horizon.Asset, counter horizon.Asset, price float64, amount float64, incrementalNativeAmountRaw float64) (*build.ManageOfferBuilder, error) {
+func (sdex *SDEX) CreateBuyOffer(base hProtocol.Asset, counter hProtocol.Asset, price float64, amount float64, incrementalNativeAmountRaw float64) (*build.ManageOfferBuilder, error) {
 	return sdex.CreateSellOffer(counter, base, 1/price, amount*price, incrementalNativeAmountRaw)
 }
 
@@ -479,16 +480,16 @@ func (sdex *SDEX) invokeAsyncCallback(asyncCallback func(hash string, err error)
 }
 
 // Assets returns the base and quote asset used by sdex
-func (sdex *SDEX) Assets() (baseAsset horizon.Asset, quoteAsset horizon.Asset, e error) {
+func (sdex *SDEX) Assets() (baseAsset hProtocol.Asset, quoteAsset hProtocol.Asset, e error) {
 	var ok bool
 	baseAsset, ok = sdex.assetMap[sdex.pair.Base]
 	if !ok {
-		return horizon.Asset{}, horizon.Asset{}, fmt.Errorf("unexpected error, base asset was not found in sdex.assetMap")
+		return hProtocol.Asset{}, hProtocol.Asset{}, fmt.Errorf("unexpected error, base asset was not found in sdex.assetMap")
 	}
 
 	quoteAsset, ok = sdex.assetMap[sdex.pair.Quote]
 	if !ok {
-		return horizon.Asset{}, horizon.Asset{}, fmt.Errorf("unexpected error, quote asset was not found in sdex.assetMap")
+		return hProtocol.Asset{}, hProtocol.Asset{}, fmt.Errorf("unexpected error, quote asset was not found in sdex.assetMap")
 	}
 
 	return baseAsset, quoteAsset, nil
@@ -562,7 +563,7 @@ func (sdex *SDEX) GetTradeHistory(pair model.TradingPair, maybeCursorStart inter
 	}
 }
 
-func (sdex *SDEX) getOrderAction(baseAsset horizon.Asset, quoteAsset horizon.Asset, trade horizon.Trade) *model.OrderAction {
+func (sdex *SDEX) getOrderAction(baseAsset hProtocol.Asset, quoteAsset hProtocol.Asset, trade hProtocol.Trade) *model.OrderAction {
 	if trade.BaseAccount != sdex.TradingAccount && trade.CounterAccount != sdex.TradingAccount {
 		return nil
 	}
@@ -598,7 +599,7 @@ func (sdex *SDEX) getOrderAction(baseAsset horizon.Asset, quoteAsset horizon.Ass
 }
 
 // returns tradeHistoryResult, hitCursorEnd, and any error
-func (sdex *SDEX) tradesPage2TradeHistoryResult(baseAsset horizon.Asset, quoteAsset horizon.Asset, tradesPage horizon.TradesPage, cursorEnd string) (*api.TradeHistoryResult, bool, error) {
+func (sdex *SDEX) tradesPage2TradeHistoryResult(baseAsset hProtocol.Asset, quoteAsset hProtocol.Asset, tradesPage hProtocol.TradesPage, cursorEnd string) (*api.TradeHistoryResult, bool, error) {
 	var cursor string
 	trades := []model.Trade{}
 
@@ -702,7 +703,7 @@ func (sdex *SDEX) GetOrderBook(pair *model.TradingPair, maxCount int32) (*model.
 
 func (sdex *SDEX) transformHorizonOrders(
 	pair *model.TradingPair,
-	side []horizon.PriceLevel,
+	side []hProtocol.PriceLevel,
 	orderAction model.OrderAction,
 	ts *model.Timestamp,
 	maxCount int32,

--- a/plugins/sdexFeed.go
+++ b/plugins/sdexFeed.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/clients/horizonclient"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
@@ -44,7 +44,7 @@ func makeSDEXFeed(url string) (*sdexFeed, error) {
 		tradingPair.Quote: *quoteAsset,
 	}
 
-	var api *horizon.Client
+	var api *horizonclient.Client
 	var ieif *IEIF
 	var network build.Network
 	if privateSdexHackVar != nil {
@@ -53,7 +53,7 @@ func makeSDEXFeed(url string) (*sdexFeed, error) {
 		network = privateSdexHackVar.Network
 	} else {
 		// use production network by default
-		api = horizon.DefaultPublicNetClient
+		api = horizonclient.DefaultPublicNetClient
 		ieif = MakeIEIF(true)
 		network = build.PublicNetwork
 	}

--- a/plugins/sdexFeed.go
+++ b/plugins/sdexFeed.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stellar/go/build"
 	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
 	"github.com/stellar/kelp/support/utils"
@@ -14,8 +15,8 @@ import (
 // sdexFeed represents a pricefeed from the SDEX
 type sdexFeed struct {
 	sdex       *SDEX
-	assetBase  *horizon.Asset
-	assetQuote *horizon.Asset
+	assetBase  *hProtocol.Asset
+	assetQuote *hProtocol.Asset
 }
 
 // ensure that it implements PriceFeed
@@ -38,7 +39,7 @@ func makeSDEXFeed(url string) (*sdexFeed, error) {
 		Base:  model.Asset(utils.Asset2CodeString(*baseAsset)),
 		Quote: model.Asset(utils.Asset2CodeString(*quoteAsset)),
 	}
-	sdexAssetMap := map[model.Asset]horizon.Asset{
+	sdexAssetMap := map[model.Asset]hProtocol.Asset{
 		tradingPair.Base:  *baseAsset,
 		tradingPair.Quote: *quoteAsset,
 	}
@@ -82,7 +83,7 @@ func makeSDEXFeed(url string) (*sdexFeed, error) {
 	}, nil
 }
 
-func parseHorizonAsset(assetString string) (*horizon.Asset, error) {
+func parseHorizonAsset(assetString string) (*hProtocol.Asset, error) {
 	parts := strings.Split(assetString, ":")
 	code := parts[0]
 	issuer := parts[1]

--- a/plugins/sellSideStrategy_test.go
+++ b/plugins/sellSideStrategy_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
 	"github.com/stretchr/testify/assert"
@@ -85,13 +85,13 @@ func TestComputeOffersToPrune(t *testing.T) {
 				return
 			}
 
-			offers := []horizon.Offer{}
+			offers := []hProtocol.Offer{}
 			for _, p := range kase.offerPrices {
 				num, den, e := model.NumberFromFloat(p, 8).AsRatio()
 				if !assert.NoError(t, e) {
 					return
 				}
-				offer := horizon.Offer{}
+				offer := hProtocol.Offer{}
 				offer.PriceR.N = num
 				offer.PriceR.D = den
 				offers = append(offers, offer)

--- a/plugins/sellStrategy.go
+++ b/plugins/sellStrategy.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stellar/kelp/model"
 
-	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/support/utils"
 )
@@ -35,8 +35,8 @@ func makeSellStrategy(
 	sdex *SDEX,
 	pair *model.TradingPair,
 	ieif *IEIF,
-	assetBase *horizon.Asset,
-	assetQuote *horizon.Asset,
+	assetBase *hProtocol.Asset,
+	assetQuote *hProtocol.Asset,
 	config *sellConfig,
 ) (api.Strategy, error) {
 	pf, e := MakeFeedPair(

--- a/plugins/submitFilter.go
+++ b/plugins/submitFilter.go
@@ -2,14 +2,14 @@ package plugins
 
 import (
 	"github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 )
 
 // SubmitFilter allows you to filter out operations before submitting to the network
 type SubmitFilter interface {
 	Apply(
 		ops []build.TransactionMutator,
-		sellingOffers []horizon.Offer, // quoted quote/base
-		buyingOffers []horizon.Offer, // quoted base/quote
+		sellingOffers []hProtocol.Offer, // quoted quote/base
+		buyingOffers []hProtocol.Offer, // quoted base/quote
 	) ([]build.TransactionMutator, error)
 }

--- a/query/botInfo.go
+++ b/query/botInfo.go
@@ -3,7 +3,7 @@ package query
 import (
 	"fmt"
 
-	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/model"
 	"github.com/stellar/kelp/support/utils"
 )
@@ -11,8 +11,8 @@ import (
 type botInfo struct {
 	Strategy      string             `json:"strategy"`
 	TradingPair   *model.TradingPair `json:"trading_pair"`
-	AssetBase     horizon.Asset      `json:"asset_base"`
-	AssetQuote    horizon.Asset      `json:"asset_quote"`
+	AssetBase     hProtocol.Asset    `json:"asset_base"`
+	AssetQuote    hProtocol.Asset    `json:"asset_quote"`
 	BalanceBase   float64            `json:"balance_base"`
 	BalanceQuote  float64            `json:"balance_quote"`
 	NumBids       int                `json:"num_bids"`

--- a/query/server.go
+++ b/query/server.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stellar/kelp/support/utils"
 
-	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
 	"github.com/stellar/kelp/plugins"
@@ -23,7 +23,7 @@ type Server struct {
 	strategyName string
 	strategy     api.Strategy
 	botConfig    trader.BotConfig
-	client       *horizon.Client
+	client       *horizonclient.Client
 	sdex         *plugins.SDEX
 	exchangeShim api.ExchangeShim
 	tradingPair  *model.TradingPair
@@ -35,7 +35,7 @@ func MakeServer(
 	strategyName string,
 	strategy api.Strategy,
 	botConfig trader.BotConfig,
-	client *horizon.Client,
+	client *horizonclient.Client,
 	sdex *plugins.SDEX,
 	exchangeShim api.ExchangeShim,
 	tradingPair *model.TradingPair,

--- a/support/utils/functions.go
+++ b/support/utils/functions.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/keypair"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/protocols/horizon/base"
@@ -141,16 +141,28 @@ func String2Asset(code string, issuer string) hProtocol.Asset {
 }
 
 // LoadAllOffers loads all the offers for a given account
-func LoadAllOffers(account string, api *horizon.Client) ([]hProtocol.Offer, error) {
+func LoadAllOffers(account string, api *horizonclient.Client) ([]hProtocol.Offer, error) {
 	// get what orders are outstanding now
-	offersPage, e := api.LoadAccountOffers(account, horizon.Limit(193))
+	offerReq := horizonclient.OfferRequest{
+		ForAccount: account,
+		Limit:      uint(193),
+	}
+
+	offersPage, e := api.Offers(offerReq)
 	if e != nil {
 		return []hProtocol.Offer{}, fmt.Errorf("Can't load offers: %s\n", e)
 	}
 
 	offersRet := offersPage.Embedded.Records
 	for len(offersPage.Embedded.Records) > 0 {
-		offersPage, e = api.LoadAccountOffers(account, horizon.Limit(193), horizon.At(offersPage.Links.Next.Href))
+		// to do: use NexOffersPage method, minimum requirement: horizonclient v1.2
+		// offersPage, e = api.NextOffersPage(offersPage)
+		offerReq = horizonclient.OfferRequest{
+			ForAccount: account,
+			Limit:      uint(193),
+			Cursor:     offersPage.Embedded.Records[0].PT,
+		}
+		offersPage, e := api.Offers(offerReq)
 		if e != nil {
 			return []hProtocol.Offer{}, fmt.Errorf("Can't load offers: %s\n", e)
 		}

--- a/terminator/terminator.go
+++ b/terminator/terminator.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/clients/horizonclient"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/model"
 	"github.com/stellar/kelp/plugins"
@@ -19,7 +19,7 @@ const terminatorKey = "term"
 
 // Terminator contains the logic to terminate offers
 type Terminator struct {
-	api                  *horizon.Client
+	api                  *horizonclient.Client
 	sdex                 *plugins.SDEX
 	tradingAccount       string
 	tickIntervalSeconds  int32
@@ -28,7 +28,7 @@ type Terminator struct {
 
 // MakeTerminator is a factory method to make a Terminator
 func MakeTerminator(
-	api *horizon.Client,
+	api *horizonclient.Client,
 	sdex *plugins.SDEX,
 	tradingAccount string,
 	tickIntervalSeconds int32,
@@ -69,8 +69,8 @@ func (t *Terminator) run() {
 	if 1 < 2 {
 		panic("need to add db-based support, manage-data based support is invalid since we don't write it from trader anymore.")
 	}
-
-	account, e := t.api.LoadAccount(t.tradingAccount)
+	accountReq := horizonclient.AccountRequest{AccountID: t.tradingAccount}
+	account, e := t.api.AccountDetail(accountReq)
 	if e != nil {
 		log.Println(e)
 		return

--- a/terminator/terminator.go
+++ b/terminator/terminator.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stellar/go/build"
 	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/model"
 	"github.com/stellar/kelp/plugins"
 	"github.com/stellar/kelp/support/utils"
@@ -123,7 +124,7 @@ func (t *Terminator) run() {
 	}
 }
 
-func convertToAsset(code string, issuer string) horizon.Asset {
+func convertToAsset(code string, issuer string) hProtocol.Asset {
 	if code == utils.Native {
 		return utils.Asset2Asset2(build.NativeAsset())
 	}
@@ -131,7 +132,7 @@ func convertToAsset(code string, issuer string) horizon.Asset {
 }
 
 // deleteOffers deletes passed in offers along with the data for the passed in hash
-func (t *Terminator) deleteOffers(sellOffers []horizon.Offer, buyOffers []horizon.Offer, botKey model.BotKey, tsMillis int64) {
+func (t *Terminator) deleteOffers(sellOffers []hProtocol.Offer, buyOffers []hProtocol.Offer, botKey model.BotKey, tsMillis int64) {
 	ops := []build.TransactionMutator{}
 	ops = append(ops, t.sdex.DeleteAllOffers(sellOffers)...)
 	ops = append(ops, t.sdex.DeleteAllOffers(buyOffers)...)

--- a/trader/config.go
+++ b/trader/config.go
@@ -3,7 +3,7 @@ package trader
 import (
 	"fmt"
 
-	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/support/toml"
 	"github.com/stellar/kelp/support/utils"
 )
@@ -57,8 +57,8 @@ type BotConfig struct {
 	// initialized later
 	tradingAccount *string
 	sourceAccount  *string // can be nil
-	assetBase      horizon.Asset
-	assetQuote     horizon.Asset
+	assetBase      hProtocol.Asset
+	assetQuote     hProtocol.Asset
 	isTradingSdex  bool
 }
 
@@ -85,21 +85,21 @@ func MakeBotConfig(
 	centralizedMinQuoteVolumeOverride *float64,
 ) *BotConfig {
 	return &BotConfig{
-		SourceSecretSeed:                 sourceSecretSeed,
-		TradingSecretSeed:                tradingSecretSeed,
-		AssetCodeA:                       assetCodeA,
-		IssuerA:                          issuerA,
-		AssetCodeB:                       assetCodeB,
-		IssuerB:                          issuerB,
-		TickIntervalSeconds:              tickIntervalSeconds,
-		MaxTickDelayMillis:               maxTickDelayMillis,
-		DeleteCyclesThreshold:            deleteCyclesThreshold,
-		SubmitMode:                       submitMode,
-		FillTrackerSleepMillis:           fillTrackerSleepMillis,
-		FillTrackerDeleteCyclesThreshold: fillTrackerDeleteCyclesThreshold,
-		HorizonURL:                       horizonURL,
-		CcxtRestURL:                      ccxtRestURL,
-		Fee:                              fee,
+		SourceSecretSeed:                   sourceSecretSeed,
+		TradingSecretSeed:                  tradingSecretSeed,
+		AssetCodeA:                         assetCodeA,
+		IssuerA:                            issuerA,
+		AssetCodeB:                         assetCodeB,
+		IssuerB:                            issuerB,
+		TickIntervalSeconds:                tickIntervalSeconds,
+		MaxTickDelayMillis:                 maxTickDelayMillis,
+		DeleteCyclesThreshold:              deleteCyclesThreshold,
+		SubmitMode:                         submitMode,
+		FillTrackerSleepMillis:             fillTrackerSleepMillis,
+		FillTrackerDeleteCyclesThreshold:   fillTrackerDeleteCyclesThreshold,
+		HorizonURL:                         horizonURL,
+		CcxtRestURL:                        ccxtRestURL,
+		Fee:                                fee,
 		CentralizedPricePrecisionOverride:  centralizedPricePrecisionOverride,
 		CentralizedVolumePrecisionOverride: centralizedVolumePrecisionOverride,
 		CentralizedMinBaseVolumeOverride:   centralizedMinBaseVolumeOverride,
@@ -141,12 +141,12 @@ func (b *BotConfig) SourceAccount() string {
 }
 
 // AssetBase returns the config's assetBase
-func (b *BotConfig) AssetBase() horizon.Asset {
+func (b *BotConfig) AssetBase() hProtocol.Asset {
 	return b.assetBase
 }
 
 // AssetQuote returns the config's assetQuote
-func (b *BotConfig) AssetQuote() horizon.Asset {
+func (b *BotConfig) AssetQuote() hProtocol.Asset {
 	return b.assetQuote
 }
 

--- a/trader/trader.go
+++ b/trader/trader.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nikhilsaraf/go-tools/multithreading"
 	"github.com/stellar/go/build"
 	"github.com/stellar/go/clients/horizon"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
 	"github.com/stellar/kelp/plugins"
@@ -22,8 +23,8 @@ const maxLumenTrust float64 = math.MaxFloat64
 type Trader struct {
 	api                   *horizon.Client
 	ieif                  *plugins.IEIF
-	assetBase             horizon.Asset
-	assetQuote            horizon.Asset
+	assetBase             hProtocol.Asset
+	assetQuote            hProtocol.Asset
 	tradingAccount        string
 	sdex                  *plugins.SDEX
 	exchangeShim          api.ExchangeShim
@@ -44,16 +45,16 @@ type Trader struct {
 	maxAssetB      float64
 	trustAssetA    float64
 	trustAssetB    float64
-	buyingAOffers  []horizon.Offer // quoted A/B
-	sellingAOffers []horizon.Offer // quoted B/A
+	buyingAOffers  []hProtocol.Offer // quoted A/B
+	sellingAOffers []hProtocol.Offer // quoted B/A
 }
 
 // MakeBot is the factory method for the Trader struct
 func MakeBot(
 	api *horizon.Client,
 	ieif *plugins.IEIF,
-	assetBase horizon.Asset,
-	assetQuote horizon.Asset,
+	assetBase hProtocol.Asset,
+	assetQuote hProtocol.Asset,
 	tradingPair *model.TradingPair,
 	tradingAccount string,
 	sdex *plugins.SDEX,
@@ -143,9 +144,9 @@ func (t *Trader) deleteAllOffers() {
 	log.Printf("deleting all offers, num. continuous update cycles with errors (including this one): %d; (deleteCyclesThreshold to be exceeded=%d)\n", t.deleteCycles, t.deleteCyclesThreshold)
 	dOps := []build.TransactionMutator{}
 	dOps = append(dOps, t.sdex.DeleteAllOffers(t.sellingAOffers)...)
-	t.sellingAOffers = []horizon.Offer{}
+	t.sellingAOffers = []hProtocol.Offer{}
 	dOps = append(dOps, t.sdex.DeleteAllOffers(t.buyingAOffers)...)
-	t.buyingAOffers = []horizon.Offer{}
+	t.buyingAOffers = []hProtocol.Offer{}
 
 	log.Printf("created %d operations to delete offers\n", len(dOps))
 	if len(dOps) > 0 {

--- a/trader/trader.go
+++ b/trader/trader.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/nikhilsaraf/go-tools/multithreading"
 	"github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/clients/horizonclient"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
@@ -21,7 +21,7 @@ const maxLumenTrust float64 = math.MaxFloat64
 
 // Trader represents a market making bot, which is composed of various parts include the strategy and various APIs.
 type Trader struct {
-	api                   *horizon.Client
+	api                   *horizonclient.Client
 	ieif                  *plugins.IEIF
 	assetBase             hProtocol.Asset
 	assetQuote            hProtocol.Asset
@@ -51,7 +51,7 @@ type Trader struct {
 
 // MakeBot is the factory method for the Trader struct
 func MakeBot(
-	api *horizon.Client,
+	api *horizonclient.Client,
 	ieif *plugins.IEIF,
 	assetBase hProtocol.Asset,
 	assetQuote hProtocol.Asset,


### PR DESCRIPTION
This PR covers part of the work required to update Kelp to use the new stellar Go sdk. This PR focuses on the `horizonclient` package.

The changes here are split into 2 parts

1. Change the deprecated types in `clients/horizon` to use `protocols/horizon`. This affects things like, Accounts, Offers, Trades and Asset types.

2.  Change the client from `clients/horizon` to `clients/horizonclient`.

**Known Issues**
- Need to upgrade to the latest Go sdk version. Needed in `functions.go` See `To Do` comment.
