### PR TITLE
Use clients/horizonclient

### DIFF
--- a/accounting/pnl/pnl.go
+++ b/accounting/pnl/pnl.go
@@ -97,7 +97,8 @@ func getTotalNativeValue(address string, cmcRef string) float64 {
 }
 
 func loadAccount(client *horizonclient.Client, address string) hProtocol.Account {
-	account, e := client.LoadAccount(address)
+	acctReq := horizonclient.AccountRequest{AccountID: address}
+	account, e := client.AccountDetail(acctReq)
 	if e != nil {
 		switch t := e.(type) {
 		case *horizonclient.Error:

--- a/accounting/pnl/pnl.go
+++ b/accounting/pnl/pnl.go
@@ -16,7 +16,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/clients/horizonclient"
+	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/plugins"
 )
@@ -51,7 +52,7 @@ func main() {
 }
 
 func getTotalNativeValue(address string, cmcRef string) float64 {
-	client := horizon.DefaultPublicNetClient
+	client := horizonclient.DefaultPublicNetClient
 	account := loadAccount(client, address)
 
 	nativeBal := 0.0
@@ -95,11 +96,11 @@ func getTotalNativeValue(address string, cmcRef string) float64 {
 	return totalNativeValue
 }
 
-func loadAccount(client *horizon.Client, address string) horizon.Account {
+func loadAccount(client *horizonclient.Client, address string) hProtocol.Account {
 	account, e := client.LoadAccount(address)
 	if e != nil {
 		switch t := e.(type) {
-		case *horizon.Error:
+		case *horizonclient.Error:
 			log.Fatal(t.Problem)
 		default:
 			log.Fatal(e)

--- a/cmd/terminate.go
+++ b/cmd/terminate.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/nikhilsaraf/go-tools/multithreading"
 	"github.com/spf13/cobra"
-	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/clients/horizonclient"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/config"
 	"github.com/stellar/kelp/model"
@@ -38,8 +38,8 @@ func init() {
 		log.Println("Started Terminator for account: ", *configFile.TradingAccount)
 
 		// --- start initialization of objects ----
-		client := &horizon.Client{
-			URL:        configFile.HorizonURL,
+		client := &horizonclient.Client{
+			HorizonURL: configFile.HorizonURL,
 			HTTP:       http.DefaultClient,
 			AppName:    "kelp",
 			AppVersion: version,

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -402,8 +402,6 @@ func runTradeCmd(options inputs) {
 	if !*options.noHeaders {
 		client.AppName = "kelp"
 		client.AppVersion = version
-		client.AppName = "kelp"
-		client.AppVersion = version
 
 		p := prefs.Make(prefsFilename)
 		if p.FirstTime() {

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -13,7 +13,6 @@ import (
 	"github.com/nikhilsaraf/go-tools/multithreading"
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
 	"github.com/stellar/go/clients/horizonclient"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/go/support/config"
@@ -195,8 +194,7 @@ func makeExchangeShimSdex(
 	l logger.Logger,
 	botConfig trader.BotConfig,
 	options inputs,
-	client *horizon.Client,
-	newClient *horizonclient.Client,
+	client *horizonclient.Client,
 	ieif *plugins.IEIF,
 	network build.Network,
 	threadTracker *multithreading.ThreadTracker,
@@ -263,7 +261,7 @@ func makeExchangeShimSdex(
 		tradingPair.Base:  botConfig.AssetBase(),
 		tradingPair.Quote: botConfig.AssetQuote(),
 	}
-	feeFn := makeFeeFn(l, botConfig, newClient)
+	feeFn := makeFeeFn(l, botConfig, client)
 	sdex := plugins.MakeSDEX(
 		client,
 		ieif,
@@ -292,7 +290,7 @@ func makeStrategy(
 	l logger.Logger,
 	network build.Network,
 	botConfig trader.BotConfig,
-	client *horizon.Client,
+	client *horizonclient.Client,
 	sdex *plugins.SDEX,
 	exchangeShim api.ExchangeShim,
 	assetBase hProtocol.Asset,
@@ -324,7 +322,7 @@ func makeStrategy(
 func makeBot(
 	l logger.Logger,
 	botConfig trader.BotConfig,
-	client *horizon.Client,
+	client *horizonclient.Client,
 	sdex *plugins.SDEX,
 	exchangeShim api.ExchangeShim,
 	ieif *plugins.IEIF,
@@ -397,13 +395,8 @@ func runTradeCmd(options inputs) {
 		Quote: model.Asset(utils.Asset2CodeString(assetQuote)),
 	}
 
-	client := &horizon.Client{
-		URL:  botConfig.HorizonURL,
-		HTTP: http.DefaultClient,
-	}
-	newClient := &horizonclient.Client{
-		// TODO horizonclient.Client has a bug in it where it does not use "/" to separate the horizonURL from the fee_stats endpoint
-		HorizonURL: botConfig.HorizonURL + "/",
+	client := &horizonclient.Client{
+		HorizonURL: botConfig.HorizonURL,
 		HTTP:       http.DefaultClient,
 	}
 	if !*options.noHeaders {
@@ -560,7 +553,7 @@ func startFillTracking(
 	l logger.Logger,
 	strategy api.Strategy,
 	botConfig trader.BotConfig,
-	client *horizon.Client,
+	client *horizonclient.Client,
 	sdex *plugins.SDEX,
 	exchangeShim api.ExchangeShim,
 	tradingPair *model.TradingPair,
@@ -607,7 +600,7 @@ func startQueryServer(
 	strategyName string,
 	strategy api.Strategy,
 	botConfig trader.BotConfig,
-	client *horizon.Client,
+	client *horizonclient.Client,
 	sdex *plugins.SDEX,
 	exchangeShim api.ExchangeShim,
 	tradingPair *model.TradingPair,
@@ -643,7 +636,7 @@ func startQueryServer(
 	}()
 }
 
-func validateTrustlines(l logger.Logger, client *horizon.Client, botConfig *trader.BotConfig) {
+func validateTrustlines(l logger.Logger, client *horizonclient.Client, botConfig *trader.BotConfig) {
 	if !botConfig.IsTradingSdex() {
 		l.Info("no need to validate trustlines because we're not using SDEX as the trading exchange")
 		return
@@ -679,7 +672,7 @@ func validateTrustlines(l logger.Logger, client *horizon.Client, botConfig *trad
 func deleteAllOffersAndExit(
 	l logger.Logger,
 	botConfig trader.BotConfig,
-	client *horizon.Client,
+	client *horizonclient.Client,
 	sdex *plugins.SDEX,
 	exchangeShim api.ExchangeShim,
 	threadTracker *multithreading.ThreadTracker,

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -402,8 +402,8 @@ func runTradeCmd(options inputs) {
 	if !*options.noHeaders {
 		client.AppName = "kelp"
 		client.AppVersion = version
-		newClient.AppName = "kelp"
-		newClient.AppVersion = version
+		client.AppName = "kelp"
+		client.AppVersion = version
 
 		p := prefs.Make(prefsFilename)
 		if p.FirstTime() {
@@ -432,7 +432,6 @@ func runTradeCmd(options inputs) {
 		botConfig,
 		options,
 		client,
-		newClient,
 		ieif,
 		network,
 		threadTracker,
@@ -643,7 +642,8 @@ func validateTrustlines(l logger.Logger, client *horizonclient.Client, botConfig
 	}
 
 	log.Printf("validating trustlines...\n")
-	account, e := client.LoadAccount(botConfig.TradingAccount())
+	acctReq := horizonclient.AccountRequest{AccountID: botConfig.TradingAccount()}
+	account, e := client.AccountDetail(acctReq)
 	if e != nil {
 		logger.Fatal(l, e)
 	}

--- a/plugins/priceFeed.go
+++ b/plugins/priceFeed.go
@@ -5,14 +5,14 @@ import (
 	"strings"
 
 	"github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
 )
 
 // privateSdexHack is a temporary hack struct for SDEX price feeds pending refactor
 type privateSdexHack struct {
-	API     *horizon.Client
+	API     *horizonclient.Client
 	Ieif    *IEIF
 	Network build.Network
 }
@@ -21,7 +21,7 @@ type privateSdexHack struct {
 var privateSdexHackVar *privateSdexHack
 
 // SetPrivateSdexHack sets the privateSdexHack variable which is temporary until the pending SDEX price feed refactor
-func SetPrivateSdexHack(api *horizon.Client, ieif *IEIF, network build.Network) error {
+func SetPrivateSdexHack(api *horizonclient.Client, ieif *IEIF, network build.Network) error {
 	if privateSdexHackVar != nil {
 		return fmt.Errorf("privateSdexHack is already set: %+v", privateSdexHackVar)
 	}

--- a/plugins/sdexFeed.go
+++ b/plugins/sdexFeed.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/clients/horizonclient"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
@@ -44,7 +44,7 @@ func makeSDEXFeed(url string) (*sdexFeed, error) {
 		tradingPair.Quote: *quoteAsset,
 	}
 
-	var api *horizon.Client
+	var api *horizonclient.Client
 	var ieif *IEIF
 	var network build.Network
 	if privateSdexHackVar != nil {
@@ -53,7 +53,7 @@ func makeSDEXFeed(url string) (*sdexFeed, error) {
 		network = privateSdexHackVar.Network
 	} else {
 		// use production network by default
-		api = horizon.DefaultPublicNetClient
+		api = horizonclient.DefaultPublicNetClient
 		ieif = MakeIEIF(true)
 		network = build.PublicNetwork
 	}

--- a/query/server.go
+++ b/query/server.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stellar/kelp/support/utils"
 
-	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
 	"github.com/stellar/kelp/plugins"
@@ -23,7 +23,7 @@ type Server struct {
 	strategyName string
 	strategy     api.Strategy
 	botConfig    trader.BotConfig
-	client       *horizon.Client
+	client       *horizonclient.Client
 	sdex         *plugins.SDEX
 	exchangeShim api.ExchangeShim
 	tradingPair  *model.TradingPair
@@ -35,7 +35,7 @@ func MakeServer(
 	strategyName string,
 	strategy api.Strategy,
 	botConfig trader.BotConfig,
-	client *horizon.Client,
+	client *horizonclient.Client,
 	sdex *plugins.SDEX,
 	exchangeShim api.ExchangeShim,
 	tradingPair *model.TradingPair,

--- a/trader/trader.go
+++ b/trader/trader.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/nikhilsaraf/go-tools/multithreading"
 	"github.com/stellar/go/build"
-	"github.com/stellar/go/clients/horizon"
+	"github.com/stellar/go/clients/horizonclient"
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
@@ -21,7 +21,7 @@ const maxLumenTrust float64 = math.MaxFloat64
 
 // Trader represents a market making bot, which is composed of various parts include the strategy and various APIs.
 type Trader struct {
-	api                   *horizon.Client
+	api                   *horizonclient.Client
 	ieif                  *plugins.IEIF
 	assetBase             hProtocol.Asset
 	assetQuote            hProtocol.Asset
@@ -51,7 +51,7 @@ type Trader struct {
 
 // MakeBot is the factory method for the Trader struct
 func MakeBot(
-	api *horizon.Client,
+	api *horizonclient.Client,
 	ieif *plugins.IEIF,
 	assetBase hProtocol.Asset,
 	assetQuote hProtocol.Asset,


### PR DESCRIPTION
This PR covers part of the work required to update Kelp to use the new stellar Go sdk. This PR focuses on changing the horizon client package from `clients/horizon` to `clients/horizonclient`.

This PR does not change all usage of `clients/horizon` as there are some instances still needed by the old `build` Package.  In particular, these two files were not changed
- `.../gui/backend/upsert_bot_config.go`
- `.../gui/backend/autogenerate_bot.go`

These will be handled in a separate PR when converting to the new `txnbuild` package.