### PR TITLE
fix op_underfunded error when replenishing top offer

### DIFF
--- a/plugins/sellSideStrategy.go
+++ b/plugins/sellSideStrategy.go
@@ -246,8 +246,17 @@ func (s *sellSideStrategy) createPrecedingOffers(
 		}
 	}
 
+	numLevelsConsumed := len(precedingLevels)
+	newTopOfferPrice := "<nil>"
+	if newTopOffer != nil {
+		newTopOfferPrice = newTopOffer.AsString()
+	}
+	log.Printf("done creating preceding offers (numLevelsConsumed=%d, hitCapacityLimit=%v, numOps=%d, newTopOfferPrice=%s)",
+		numLevelsConsumed, hitCapacityLimit, len(ops), newTopOfferPrice,
+	)
+
 	// hitCapacityLimit can be updated after the check inside the for loop
-	return len(precedingLevels), hitCapacityLimit, ops, newTopOffer, nil
+	return numLevelsConsumed, hitCapacityLimit, ops, newTopOffer, nil
 }
 
 // UpdateWithOps impl

--- a/plugins/sellSideStrategy.go
+++ b/plugins/sellSideStrategy.go
@@ -219,9 +219,8 @@ func (s *sellSideStrategy) createPrecedingOffers(
 
 	for i := 0; i < len(precedingLevels); i++ {
 		if hitCapacityLimit {
-			// we consider the ith level consumed because we don't want to create an offer for it anyway since we hit the capacity limit
-			log.Printf("%s, hitCapacityLimit in preceding level loop, returning numLevelsConsumed=%d\n", s.action, i+1)
-			return (i + 1), true, ops, newTopOffer, nil
+			log.Printf("%s, hitCapacityLimit in preceding level loop, returning numLevelsConsumed=%d\n", s.action, i)
+			return i, true, ops, newTopOffer, nil
 		}
 
 		targetPrice, targetAmount, e := s.computeTargets(precedingLevels[i])

--- a/plugins/sellSideStrategy.go
+++ b/plugins/sellSideStrategy.go
@@ -220,7 +220,7 @@ func (s *sellSideStrategy) createPrecedingOffers(
 	for i := 0; i < len(precedingLevels); i++ {
 		if hitCapacityLimit {
 			// we consider the ith level consumed because we don't want to create an offer for it anyway since we hit the capacity limit
-			log.Printf("hitCapacityLimit in preceding level loop, returning numLevelsConsumed=%d\n", i+1)
+			log.Printf("%s, hitCapacityLimit in preceding level loop, returning numLevelsConsumed=%d\n", s.action, i+1)
 			return (i + 1), true, ops, newTopOffer, nil
 		}
 
@@ -251,8 +251,8 @@ func (s *sellSideStrategy) createPrecedingOffers(
 	if newTopOffer != nil {
 		newTopOfferPrice = newTopOffer.AsString()
 	}
-	log.Printf("done creating preceding offers (numLevelsConsumed=%d, hitCapacityLimit=%v, numOps=%d, newTopOfferPrice=%s)",
-		numLevelsConsumed, hitCapacityLimit, len(ops), newTopOfferPrice,
+	log.Printf("%s, done creating preceding offers (numLevelsConsumed=%d, hitCapacityLimit=%v, numOps=%d, newTopOfferPrice=%s)",
+		s.action, numLevelsConsumed, hitCapacityLimit, len(ops), newTopOfferPrice,
 	)
 
 	// hitCapacityLimit can be updated after the check inside the for loop

--- a/plugins/sellSideStrategy.go
+++ b/plugins/sellSideStrategy.go
@@ -277,7 +277,8 @@ func (s *sellSideStrategy) UpdateWithOps(offers []hProtocol.Offer) (ops []build.
 		offers = append([]hProtocol.Offer{{}}, offers...)
 	}
 
-	// next we want to adjust our remaining offers to be in line with what is desired, creating new offers that may not exist at the end of our existing offers
+	// next we want to adjust our remaining offers to be in line with what is desired
+	// either modifying the existing offers, or creating new offers at the end of our existing offers
 	for i := numLevelsConsumed; i < len(s.currentLevels); i++ {
 		isModify := i < len(offers)
 		// we only want to delete offers after we hit the capacity limit which is why we perform this check in the beginning


### PR DESCRIPTION
do not return an extra level for `numLevelsConsumed` because we may want to delete or modify it
fixes #250