### PR TITLE
Update disclaimers in README and welcome page (closes #485)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To learn more about the Stellar protocol check out [Stellar Videos on Coinbase E
 
 **Important Disclaimer: Be Smart and Go Slow.** Whenever you trade on Stellar, you are trading with volatile assets, in volatile markets, and you risk losing money. Kelp is an experimental software that contains bugs. Use Kelp at your own risk. There is no guarantee you'll make a profit from using our bots or strategies. In fact, if you set bad parameters or market conditions change, Kelp might help you lose money very fast. So be smart and go slow.
 
-Your use of Kelp is governed by the Apache 2.0 open-source license. Please note that SDF’s interactions with you are governed by the SDF [Terms of Service](https://www.stellar.org/terms-of-service) and [Privacy Policy](https://www.stellar.org/privacy-policy).
+Your use of Kelp is governed by the Apache 2.0 open-source license. Please note that SDF’s interactions with you are governed by the SDF [Terms of Service][tos] and [Privacy Policy][privacy-policy].
 
 ![Kelp GUI screenshot](resources/screenshots/gui_screenshot.png)
 
@@ -432,6 +432,8 @@ See the [Code of Conduct](CODE_OF_CONDUCT.md).
 [stellar-downloader]: https://github.com/nikhilsaraf/stellar-downloader
 [stackexchange]: https://stellar.stackexchange.com/
 [cla]: https://forms.gle/9FBgjDnNYv1abnKD7
+[tos]: https://www.stellar.org/terms-of-service
+[privacy-policy]: https://www.stellar.org/privacy-policy
 [announcements-group]: https://groups.google.com/forum/#!forum/kelp-announce
 [discussions-group]: https://groups.google.com/forum/#!forum/kelp-talk
 [github-bug-report]: https://github.com/stellar/kelp/issues/new?template=bug_report.md

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Kelp is built to:
 
 To learn more about the Stellar protocol check out [Stellar Videos on Coinbase Earn][stellar coinbase earn], or [this video about the Stellar DEX created by Lumenauts][sdex explainer video], or read more about it on the [Stellar Website][intro to stellar].
 
+## Be Smart and Go Slow
+
+**Important Disclaimer: Be Smart and Go Slow.** Whenever you trade on Stellar, you are trading with volatile assets, in volatile markets, and you risk losing money. Kelp is an experimental software that contains bugs. Use Kelp at your own risk. There is no guarantee you'll make a profit from using our bots or strategies. In fact, if you set bad parameters or market conditions change, Kelp might help you lose money very fast. So be smart and go slow.
+
+Your use of Kelp is governed by the Apache 2.0 open-source license. Please note that SDF’s interactions with you are governed by the SDF [Terms of Service](https://www.stellar.org/terms-of-service) and [Privacy Policy](https://www.stellar.org/privacy-policy).
+
 ![Kelp GUI screenshot](resources/screenshots/gui_screenshot.png)
 
 # Sign up for the new [announcements distribution list][announcements-group] and [user mailing list][discussions-group]
@@ -42,7 +48,6 @@ To learn more about the Stellar protocol check out [Stellar Videos on Coinbase E
          * [Download CCXT Binary](#download-ccxt-binary)
          * [Run CCXT using Docker](#run-ccxt-using-docker)
       * [Using Postgres](#using-postgres)
-      * [Be Smart and Go Slow](#be-smart-and-go-slow)
    * [Components](#components)
       * [Strategies](#strategies)
       * [Price Feeds](#price-feeds)
@@ -188,10 +193,6 @@ You can find more details on the [CCXT_REST github page][ccxt-rest].
 [Postgres][postgres] must be installed for Kelp to automatically write trades to a sql database along with updating the trader config file.
 
 </details>
-
-## Be Smart and Go Slow
-
-_Whenever you trade on Stellar, you are trading with volatile assets, in volatile markets, and you risk losing money. Use Kelp at your own risk. There is no guarantee you'll make a profit from using our bots or strategies. In fact, if you set bad parameters or market conditions change, Kelp might help you **lose** money very fast. So be smart and go slow._
 
 # Components
 

--- a/gui/web/src/components/molecules/Welcome/Welcome.js
+++ b/gui/web/src/components/molecules/Welcome/Welcome.js
@@ -48,7 +48,7 @@ class Welcome extends Component {
 
     const kelpLogo = (
       <div className={styles.image}>
-        <img className={styles.symbol} src={symbol} alt="Kelp Symbol"/>
+        <img className={styles.symbol} src={symbol} alt="Kelp Symbol" />
       </div>
     );
 
@@ -61,15 +61,15 @@ class Welcome extends Component {
           </h3>
 
           <p className={styles.text}>
-          Kelp is a free and open-source trading bot for the Stellar Decentralized Exchange and centralized exchanges.
+            "Kelp is a free and open-source trading bot for the Stellar Decentralized Exchange and centralized exchanges. Kelp is programmed to support multiple trading schemes. This GUI of Kelp is limited to the Stellar Decentralized Exchange with only the buysell scheme.
           </p>
 
           <p className={styles.text}>
-          Kelp comes with multiple trading strategies out-of-the-box. This GUI of Kelp is limited to the Stellar Decentralized Exchange with the buysell strategy only.
+            You can use this GUI to define your own parameters to quickly get up and running with a trading bot in a matter of minutes.
           </p>
 
           <p className={styles.text}>
-          You can use this GUI to define your own parameters to quickly get up and running with a trading bot in a matter of minutes.
+            Please note that SDF does not and cannot provide any recommendations or advice, express or implicit, concerning trading schemes, parameters, assets, or any other trading factor.
           </p>
 
           <div className={styles.footer}>
@@ -87,21 +87,24 @@ class Welcome extends Component {
           </h3>
 
           <p className={styles.text}>
-          Prior to using this software, please note the following:
+            Prior to using this software, please note the following:
           </p>
 
           <ol className={styles.text}>
             <li>
-              We do not recommend using this software on mainnet. This is experimental software, has many known bugs, and is not yet ready for use on mainnet. You could lose significant value by using this software on mainnet. 
+              We do not recommend using this software on mainnet. This is experimental software, has many known bugs, and is not yet ready for use on mainnet. You could lose significant value by using this software on mainnet.
             </li>
             <li>
-              If you do alter the code and use it on mainnet, you acknowledge and agree that you fully assume full risk of doing so, and SDF shall not be held liable under any legal theory for loss of funds for any reason. 
+              If you do alter the code and use it on mainnet, you acknowledge and agree that you fully assume full risk of doing so, and SDF shall not be held liable under any legal theory for loss of funds for any reason.
             </li>
             <li>
               The experience you have with this software may be very different from what you will have on the final software that is made public for use on the mainnet.
             </li>
             <li>
-              This software is provided under Apache 2.0. Please review the license carefully. 
+              This software is provided under Apache 2.0. Please review the license carefully.
+            </li>
+            <li>
+              You are responsible for determining the legal and regulatory requirements and restrictions concerning your use of this software. Do not use the software if your usage violates any laws or regulations applicable to you.
             </li>
           </ol>
 
@@ -121,7 +124,7 @@ class Welcome extends Component {
     return (
       <div className={wrapperClasses}>
         {pageDisplay}
-        <span className={styles.backdrop}/>
+        <span className={styles.backdrop} />
       </div>
     );
   }

--- a/gui/web/src/components/molecules/Welcome/Welcome.js
+++ b/gui/web/src/components/molecules/Welcome/Welcome.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import styles from './Welcome.module.scss';
 import classNames from 'classnames';
 import Button from '../../atoms/Button/Button';
@@ -61,11 +61,11 @@ class Welcome extends Component {
           </h3>
 
           <p className={styles.text}>
-            "Kelp is a free and open-source trading bot for the Stellar Decentralized Exchange and centralized exchanges. Kelp is programmed to support multiple trading schemes. This GUI of Kelp is limited to the Stellar Decentralized Exchange with only the buysell scheme.
+            Kelp is a free and open-source trading bot for the Stellar Decentralized Exchange and centralized exchanges. Kelp is programmed to support multiple trading schemes. This GUI of Kelp is limited to the Stellar Decentralized Exchange with only the buysell scheme.
           </p>
 
           <p className={styles.text}>
-            You can use this GUI to define your own parameters to quickly get up and running with a trading bot in a matter of minutes.
+            You can use this GUI to define your own parameters for each trading scheme to quickly get up and running with a trading bot in a matter of minutes.
           </p>
 
           <p className={styles.text}>


### PR DESCRIPTION
This PR updates the disclaimers in the `README` and GUI welcome page, based on conversations with SDF Legal. It closes #485. There are no known limitations. 

<img width="702" alt="Welcome Screen 1" src="https://user-images.githubusercontent.com/1740974/91609420-41344980-e92c-11ea-8ea5-5d73ae6f2805.png">

<img width="698" alt="Welcome Screen 2" src="https://user-images.githubusercontent.com/1740974/91609862-05e64a80-e92d-11ea-956b-deae075cdd2a.png">

