### PR TITLE
Remove OSPath.String() call in GUI backend (closes #430)

### DIFF
--- a/gui/backend/get_bot_info.go
+++ b/gui/backend/get_bot_info.go
@@ -68,12 +68,12 @@ func (s *APIServer) runGetBotInfoDirect(w http.ResponseWriter, botName string) {
 	var botConfig trader.BotConfig
 	e = config.Read(traderFilePath.Native(), &botConfig)
 	if e != nil {
-		s.writeErrorJson(w, fmt.Sprintf("cannot read bot config at path '%s': %s\n", traderFilePath, e))
+		s.writeErrorJson(w, fmt.Sprintf("cannot read bot config at path '%s': %s\n", traderFilePath.AsString(), e))
 		return
 	}
 	e = botConfig.Init()
 	if e != nil {
-		s.writeErrorJson(w, fmt.Sprintf("cannot init bot config at path '%s': %s\n", traderFilePath, e))
+		s.writeErrorJson(w, fmt.Sprintf("cannot init bot config at path '%s': %s\n", traderFilePath.AsString(), e))
 		return
 	}
 


### PR DESCRIPTION
This PR removes a call to `OSPath.String()` in the GUI backend. The call occurs because the error format invokes the `%s` format string on an `OSPath` variable as input. That calls Go's Stringer tool, which in turn invokes the `OSPath.String()` method. To avoid this, we now pass the result of `.AsString()` to the error formatter. This closes #430.