### PR TITLE
Add more granular Kelp app names (closes #488)

### DIFF
--- a/cmd/server_amd64.go
+++ b/cmd/server_amd64.go
@@ -209,9 +209,15 @@ func init() {
 			HTTP:       http.DefaultClient,
 		}
 		if !*options.noHeaders {
-			apiTestNet.AppName = "kelp-ui"
+			if *options.noElectron {
+				apiTestNet.AppName = "kelp--gui-desktop--admin-browser"
+				apiPubNet.AppName = "kelp--gui-desktop--admin-browser"
+			} else {
+				apiTestNet.AppName = "kelp--gui-desktop--admin-electron"
+				apiPubNet.AppName = "kelp--gui-desktop--admin-electron"
+			}
+
 			apiTestNet.AppVersion = version
-			apiPubNet.AppName = "kelp-ui"
 			apiPubNet.AppVersion = version
 
 			p := prefs.Make(prefsFilename)

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -514,9 +514,9 @@ func runTradeCmd(options inputs) {
 		HTTP:       http.DefaultClient,
 	}
 	if !*options.noHeaders {
-		client.AppName = "kelp"
+		client.AppName = "kelp--cli--bot"
 		if *options.ui {
-			client.AppName = "kelp-ui"
+			client.AppName = "kelp--gui-desktop--bot"
 		}
 		client.AppVersion = version
 


### PR DESCRIPTION
**What**
This PR adds more granular Kelp app names. This directly implements the instructions in, and closes #488. 

**Why**
More granular app names will provide more visibility into the source of various requests, along multiple axes for analysis (GUI vs CLI, Desktop vs Browser).

**Known Limitations**
N/A