### PR TITLE
Disallow invalid characters in bot name (closes #429)

### DIFF
--- a/cmd/server_amd64.go
+++ b/cmd/server_amd64.go
@@ -114,6 +114,11 @@ func init() {
 			logFilepath = uiLogsDirPath.Join(logFilename)
 			setLogFile(l, logFilepath.Native())
 
+			e = backend.InitBotNameRegex()
+			if e != nil {
+				panic(errors.Wrap(e, "could not init BotNameRegex: "))
+			}
+
 			if *options.verbose {
 				astilog.SetDefaultLogger()
 			}

--- a/gui/backend/upsert_bot_config.go
+++ b/gui/backend/upsert_bot_config.go
@@ -144,6 +144,11 @@ func (s *APIServer) validateConfigs(req upsertBotConfigRequest) *upsertBotConfig
 		}
 	}
 
+	invalidChars := "<>"
+	if strings.Contains(req.Name, invalidChars) {
+		errResp.Name = fmt.Sprintf("invalid bot name: cannot contain the following characters: %s", invalidChars)
+		hasError = true
+	}
 	if req.TraderConfig.AssetCodeA == "" || len(req.TraderConfig.AssetCodeA) > 12 {
 		errResp.TraderConfig.AssetCodeA = "1 - 12 characters"
 		hasError = true

--- a/gui/backend/upsert_bot_config.go
+++ b/gui/backend/upsert_bot_config.go
@@ -196,6 +196,10 @@ func isBotNameValid(botName string) bool {
 
 // InitBotNameRegex initializes the regex for bot names.
 func InitBotNameRegex() (e error) {
+	if botNameRegex != nil {
+		return fmt.Errorf("botname regex already defined at init")
+	}
+
 	botNameRegex, e = regexp.Compile(`^[a-zA-Z0-9\- ]+$`)
 	if e != nil {
 		return fmt.Errorf("could not compile botname regex: %s", e)

--- a/gui/backend/upsert_bot_config_test.go
+++ b/gui/backend/upsert_bot_config_test.go
@@ -1,0 +1,73 @@
+package backend
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stellar/kelp/gui/model2"
+	"github.com/stellar/kelp/support/kelpos"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsBotNameValid(t *testing.T) {
+	// TODO: Define tables.
+	testCases := []struct {
+		name      string
+		botName   string
+		strategy  string
+		wantValid bool
+		// TODO: Define test struct.
+	}{
+		{
+			name:      "success default",
+			botName:   "George the Friendly Octopus",
+			wantValid: true,
+		},
+		{
+			name:      "success numeric",
+			botName:   "George the 1337 Octopus",
+			wantValid: true,
+		},
+		{
+			name:      "success dash",
+			botName:   "George-the-Friendly-Octopus",
+			wantValid: true,
+		},
+		{
+			name:      "failure <>",
+			botName:   "George<>the Friendly Octopus",
+			wantValid: false,
+		},
+		{
+			name:      "failure \\/",
+			botName:   "George\\/the Friendly Octopus",
+			wantValid: false,
+		},
+		// TODO: Define each test case.
+	}
+
+	for _, k := range testCases {
+		t.Run(k.name, func(t *testing.T) {
+			// errors would be thrown by the `regex` package, not due to kelp logic
+			gotValid, gotErr := isBotNameValid(k.botName)
+			assert.NoError(t, gotErr)
+			assert.Equal(t, k.wantValid, gotValid)
+			// early return on unsupported bot names, so we do not write an invalid filename
+			if !k.wantValid {
+				return
+			}
+
+			// confirm that we can write and delete an empty file to the bot's filepath
+			filenamePair := model2.GetBotFilenames(k.botName, "buysell")
+			fileBase, e := kelpos.MakeOsPathBase()
+			filePath := fileBase.Join(filenamePair.Trader)
+			assert.NoError(t, e)
+			e = ioutil.WriteFile(filePath.Native(), []byte{}, 0644)
+			assert.NoError(t, e)
+
+			e = os.Remove(filePath.Native())
+			assert.NoError(t, e)
+		})
+	}
+}

--- a/gui/backend/upsert_bot_config_test.go
+++ b/gui/backend/upsert_bot_config_test.go
@@ -96,7 +96,7 @@ func TestIsBotNameValid(t *testing.T) {
 			// confirm that we can write and delete an empty file to the bot's filepath
 			filenamePair := model2.GetBotFilenames(k.botName, "buysell")
 			fileBase := os.TempDir()
-			filePath := fmt.Sprintf("%s%s", fileBase, filenamePair.Trader)
+			filePath := fmt.Sprintf("%s/%s", fileBase, filenamePair.Trader)
 			e = ioutil.WriteFile(filePath, []byte{}, 0644)
 			if !assert.NoError(t, e) {
 				return

--- a/gui/backend/upsert_bot_config_test.go
+++ b/gui/backend/upsert_bot_config_test.go
@@ -11,13 +11,11 @@ import (
 )
 
 func TestIsBotNameValid(t *testing.T) {
-	// TODO: Define tables.
 	testCases := []struct {
 		name      string
 		botName   string
 		strategy  string
 		wantValid bool
-		// TODO: Define test struct.
 	}{
 		{
 			name:      "success default",
@@ -44,7 +42,6 @@ func TestIsBotNameValid(t *testing.T) {
 			botName:   "George\\/the Friendly Octopus",
 			wantValid: false,
 		},
-		// TODO: Define each test case.
 	}
 
 	for _, k := range testCases {


### PR DESCRIPTION
**What**
This PR disallows invalid characters in the bot name. The screenshot displays the fix, surfaced in the GUI. This closes #429.
<img width="564" alt="Disallow invalid characters in bot name" src="https://user-images.githubusercontent.com/1740974/94975768-874e7100-04c7-11eb-9206-ff9597f9e78a.png">


**Why**
From #428: "When naming a bot with characters such as `<` and or` >` it attempts to create a file with that name and also remove that file when deleting which fails."

**Known limitations**
N/A