### PR TITLE
Add isTestnet to metric common props (part of #516)

### DIFF
--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -527,6 +527,7 @@ func runTradeCmd(options inputs) {
 		botConfig.TickIntervalSeconds,
 		botConfig.TradingExchange,
 		botConfig.TradingPair(),
+		strings.Contains(botConfig.HorizonURL, "test"),
 	)
 	if e != nil {
 		logger.Fatal(l, fmt.Errorf("could not generate metrics tracker: %s", e))

--- a/support/metrics/metricsTracker.go
+++ b/support/metrics/metricsTracker.go
@@ -57,6 +57,7 @@ type commonProps struct {
 	Exchange                  string  `json:"exchange"`
 	TradingPair               string  `json:"trading_pair"`
 	SecondsSinceStart         float64 `json:"seconds_since_start"`
+	IsTestnet                 bool    `json:"is_testnet"`
 }
 
 // updateProps holds the properties for the update Amplitude event.
@@ -113,6 +114,7 @@ func MakeMetricsTracker(
 	updateTimeIntervalSeconds int32,
 	exchange string,
 	tradingPair string,
+	isTestnet bool,
 ) (*MetricsTracker, error) {
 	props := commonProps{
 		CliVersion:                version,
@@ -124,6 +126,7 @@ func MakeMetricsTracker(
 		UpdateTimeIntervalSeconds: updateTimeIntervalSeconds,
 		Exchange:                  exchange,
 		TradingPair:               tradingPair,
+		IsTestnet:                 isTestnet,
 	}
 
 	return &MetricsTracker{


### PR DESCRIPTION
This PR adds an `isTestnet` boolean field to the `commonProps` `struct` used in tracking metrics. Part of #516.