### PR TITLE
Add device ID to metric event props (part of #516)

### DIFF
--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/denisbrodbeck/machineid"
 	"github.com/nikhilsaraf/go-tools/multithreading"
 	"github.com/spf13/cobra"
 
@@ -513,8 +514,14 @@ func runTradeCmd(options inputs) {
 		guiVersionFlag = guiVersion
 	}
 
+	deviceID, e := machineid.ID()
+	if e != nil {
+		logger.Fatal(l, fmt.Errorf("could not generate machine id: %s", e))
+	}
+
 	metricsTracker, e := metrics.MakeMetricsTracker(
 		userID,
+		deviceID,
 		amplitudeAPIKey,
 		httpClient,
 		botStart,

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 81ecd9a85e0426d4a6332659b95c7cc3f835614b02d5b9c007e90971359167f9
-updated: 2020-07-14T01:36:52.028479+05:30
+hash: e4b1c95fb01f3196f86de34872d34c6961c0358a4d6ad7647536894b7b152420
+updated: 2020-10-13T13:50:02.186642-07:00
 imports:
 - name: cloud.google.com/go
   version: 310d83b78255a1605c3bd3a9ffe1606cf09ebcac
@@ -49,6 +49,8 @@ imports:
   version: d8f796af33cc11cb798c1aaeb27a4ebc5099927d
   subpackages:
   - spew
+- name: github.com/denisbrodbeck/machineid
+  version: f07179bb15a0bec252453468aa607c670f5c12b5
 - name: github.com/fsnotify/fsnotify
   version: 7f4cf4dd2b522a984eaca51d1ccee54101d3414a
 - name: github.com/go-chi/chi
@@ -217,6 +219,7 @@ imports:
   subpackages:
   - unix
   - windows
+  - windows/registry
 - name: golang.org/x/text
   version: afb9336c4530b4b18f37130eab53f245f7d6821e
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -59,3 +59,5 @@ import:
   version: v1.2.0
 - package: github.com/openlyinc/pointy
   version: 945de578d11bbf43bd9729c2ea0837735a21d475
+- package: github.com/denisbrodbeck/machineid
+  version: v1.0.1

--- a/support/metrics/metricsTracker.go
+++ b/support/metrics/metricsTracker.go
@@ -24,11 +24,12 @@ const (
 // and can be used to directly send events to the
 // Amplitude HTTP API.
 type MetricsTracker struct {
-	client *http.Client
-	apiKey string
-	userID string
-	props  commonProps
-	start  time.Time
+	client   *http.Client
+	apiKey   string
+	userID   string
+	deviceID string
+	props    commonProps
+	start    time.Time
 }
 
 // TODO DS Investigate other fields to add to this top-level event.
@@ -101,6 +102,7 @@ func (ar amplitudeResponse) String() string {
 // MakeMetricsTracker is a factory method to create a `metrics.Tracker`.
 func MakeMetricsTracker(
 	userID string,
+	deviceID string,
 	apiKey string,
 	client *http.Client,
 	start time.Time,
@@ -127,11 +129,12 @@ func MakeMetricsTracker(
 	}
 
 	return &MetricsTracker{
-		client: client,
-		apiKey: apiKey,
-		userID: userID,
-		props:  props,
-		start:  start,
+		client:   client,
+		apiKey:   apiKey,
+		userID:   userID,
+		deviceID: deviceID,
+		props:    props,
+		start:    start,
 	}, nil
 }
 
@@ -177,7 +180,7 @@ func (mt *MetricsTracker) sendEvent(eventType string, eventProps interface{}) er
 		Events: []event{{
 			UserID:    mt.userID,
 			SessionID: mt.start.Unix() * 1000, // convert to millis based on docs
-			DeviceID:  mt.userID,
+			DeviceID:  mt.deviceID,
 			EventType: eventType,
 			Props:     eventProps,
 		}},


### PR DESCRIPTION
This PR adds the device ID to the metric tracker's event properties. Part of #516.

Before: the device ID is the same as the user ID.
<img width="809" alt="Before: device ID equals user ID" src="https://user-images.githubusercontent.com/1740974/95901042-9cd55d80-0d47-11eb-9bef-04cb5413ebeb.png">

After: the device ID is library generated and distinct from the user ID.
<img width="811" alt="After: device ID is machine generated" src="https://user-images.githubusercontent.com/1740974/95901098-afe82d80-0d47-11eb-9e0b-aef373aed985.png">