### PR TITLE
Disable metrics tracking with no headers (part of #516)

### DIFF
--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -527,6 +527,7 @@ func runTradeCmd(options inputs) {
 		botConfig.TickIntervalSeconds,
 		botConfig.TradingExchange,
 		botConfig.TradingPair(),
+		*options.noHeaders, // disable metrics if the CLI specified no headers
 	)
 	if e != nil {
 		logger.Fatal(l, fmt.Errorf("could not generate metrics tracker: %s", e))

--- a/support/metrics/metricsTracker.go
+++ b/support/metrics/metricsTracker.go
@@ -24,11 +24,12 @@ const (
 // and can be used to directly send events to the
 // Amplitude HTTP API.
 type MetricsTracker struct {
-	client *http.Client
-	apiKey string
-	userID string
-	props  commonProps
-	start  time.Time
+	client     *http.Client
+	apiKey     string
+	userID     string
+	props      commonProps
+	start      time.Time
+	isDisabled bool
 }
 
 // TODO DS Investigate other fields to add to this top-level event.
@@ -113,6 +114,7 @@ func MakeMetricsTracker(
 	updateTimeIntervalSeconds int32,
 	exchange string,
 	tradingPair string,
+	isDisabled bool,
 ) (*MetricsTracker, error) {
 	props := commonProps{
 		CliVersion:                version,
@@ -127,11 +129,12 @@ func MakeMetricsTracker(
 	}
 
 	return &MetricsTracker{
-		client: client,
-		apiKey: apiKey,
-		userID: userID,
-		props:  props,
-		start:  start,
+		client:     client,
+		apiKey:     apiKey,
+		userID:     userID,
+		props:      props,
+		start:      start,
+		isDisabled: isDisabled,
 	}, nil
 }
 
@@ -165,7 +168,7 @@ func (mt *MetricsTracker) SendDeleteEvent(exit bool) error {
 }
 
 func (mt *MetricsTracker) sendEvent(eventType string, eventProps interface{}) error {
-	if mt.apiKey == "" || mt.userID == "-1" {
+	if mt.apiKey == "" || mt.userID == "-1" || mt.isDisabled {
 		log.Printf("metric - not sending event metric of type '%s' because metrics are disabled", eventType)
 		return nil
 	}

--- a/support/metrics/metricsTracker.go
+++ b/support/metrics/metricsTracker.go
@@ -31,7 +31,6 @@ type MetricsTracker struct {
 	props      commonProps
 	start      time.Time
 	isDisabled bool
-	isTestnet  bool
 }
 
 // TODO DS Investigate other fields to add to this top-level event.
@@ -142,7 +141,6 @@ func MakeMetricsTracker(
 		props:      props,
 		start:      start,
 		isDisabled: isDisabled,
-		isTestnet:  isTestnet,
 	}, nil
 }
 

--- a/support/metrics/metricsTracker.go
+++ b/support/metrics/metricsTracker.go
@@ -31,6 +31,7 @@ type MetricsTracker struct {
 	props      commonProps
 	start      time.Time
 	isDisabled bool
+	isTestnet  bool
 }
 
 // TODO DS Investigate other fields to add to this top-level event.


### PR DESCRIPTION
This PR disables metrics tracking if the `no-headers` flag is set to `true` in the CLI. Part of #516.

I confirmed this by setting the `userID=12345`, defining the API key, and running `kelp trade` with `no-headers=true`. I still got the expected log line on startup:
```metric - not sending event metric of type 'ce:test_startup' because metrics are disabled```