### PR TITLE
Send update event execution duration with metrics (part of #516)

### DIFF
--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -506,7 +506,7 @@ func runTradeCmd(options inputs) {
 	botConfig = convertDeprecatedBotConfigValues(l, botConfig)
 	l.Infof("Trading %s:%s for %s:%s\n", botConfig.AssetCodeA, botConfig.IssuerA, botConfig.AssetCodeB, botConfig.IssuerB)
 
-	userID := "-1" // TODO DS Properly generate and save user ID.
+	userID := "12345" // TODO DS Properly generate and save user ID.
 	httpClient := &http.Client{}
 	var guiVersionFlag string
 	if *options.ui {

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -506,7 +506,7 @@ func runTradeCmd(options inputs) {
 	botConfig = convertDeprecatedBotConfigValues(l, botConfig)
 	l.Infof("Trading %s:%s for %s:%s\n", botConfig.AssetCodeA, botConfig.IssuerA, botConfig.AssetCodeB, botConfig.IssuerB)
 
-	userID := "12345" // TODO DS Properly generate and save user ID.
+	userID := "-1" // TODO DS Properly generate and save user ID.
 	httpClient := &http.Client{}
 	var guiVersionFlag string
 	if *options.ui {

--- a/support/metrics/metricsTracker.go
+++ b/support/metrics/metricsTracker.go
@@ -62,7 +62,8 @@ type commonProps struct {
 // updateProps holds the properties for the update Amplitude event.
 type updateProps struct {
 	commonProps
-	Success bool `json:"success"`
+	Success        bool  `json:"success"`
+	UpdateDuration int64 `json:"update_duration"`
 }
 
 // deleteProps holds the properties for the delete Amplitude event.
@@ -141,12 +142,13 @@ func (mt *MetricsTracker) SendStartupEvent() error {
 }
 
 // SendUpdateEvent sends the update Amplitude event.
-func (mt *MetricsTracker) SendUpdateEvent(now time.Time, success bool) error {
+func (mt *MetricsTracker) SendUpdateEvent(now time.Time, success bool, updateDuration int64) error {
 	commonProps := mt.props
 	commonProps.SecondsSinceStart = now.Sub(mt.start).Seconds()
 	updateProps := updateProps{
-		commonProps: commonProps,
-		Success:     success,
+		commonProps:    commonProps,
+		Success:        success,
+		UpdateDuration: updateDuration,
 	}
 	return mt.sendEvent(updateEventName, updateProps)
 }

--- a/support/metrics/metricsTracker.go
+++ b/support/metrics/metricsTracker.go
@@ -62,8 +62,8 @@ type commonProps struct {
 // updateProps holds the properties for the update Amplitude event.
 type updateProps struct {
 	commonProps
-	Success        bool  `json:"success"`
-	UpdateDuration int64 `json:"update_duration"`
+	Success         bool  `json:"success"`
+	MillisForUpdate int64 `json:"millis_for_update"`
 }
 
 // deleteProps holds the properties for the delete Amplitude event.
@@ -142,13 +142,13 @@ func (mt *MetricsTracker) SendStartupEvent() error {
 }
 
 // SendUpdateEvent sends the update Amplitude event.
-func (mt *MetricsTracker) SendUpdateEvent(now time.Time, success bool, updateDuration int64) error {
+func (mt *MetricsTracker) SendUpdateEvent(now time.Time, success bool, millisForUpdate int64) error {
 	commonProps := mt.props
 	commonProps.SecondsSinceStart = now.Sub(mt.start).Seconds()
 	updateProps := updateProps{
-		commonProps:    commonProps,
-		Success:        success,
-		UpdateDuration: updateDuration,
+		commonProps:     commonProps,
+		Success:         success,
+		MillisForUpdate: millisForUpdate,
 	}
 	return mt.sendEvent(updateEventName, updateProps)
 }

--- a/trader/trader.go
+++ b/trader/trader.go
@@ -120,9 +120,11 @@ func (t *Trader) Start() {
 	for {
 		currentUpdateTime := time.Now()
 		if lastUpdateTime.IsZero() || t.timeController.ShouldUpdate(lastUpdateTime, currentUpdateTime) {
+			startUpdate := time.Now()
 			success := t.update()
+			updateDuration := time.Since(startUpdate)
 			e := t.threadTracker.TriggerGoroutine(func(inputs []interface{}) {
-				e := t.metricsTracker.SendUpdateEvent(currentUpdateTime, success)
+				e := t.metricsTracker.SendUpdateEvent(currentUpdateTime, success, updateDuration.Milliseconds())
 				if e != nil {
 					log.Printf("failed to send update event metric: %s", e)
 				}

--- a/trader/trader.go
+++ b/trader/trader.go
@@ -120,9 +120,8 @@ func (t *Trader) Start() {
 	for {
 		currentUpdateTime := time.Now()
 		if lastUpdateTime.IsZero() || t.timeController.ShouldUpdate(lastUpdateTime, currentUpdateTime) {
-			startUpdate := time.Now()
 			success := t.update()
-			millisForUpdate := time.Since(startUpdate).Milliseconds()
+			millisForUpdate := time.Since(currentUpdateTime).Milliseconds()
 			e := t.threadTracker.TriggerGoroutine(func(inputs []interface{}) {
 				e := t.metricsTracker.SendUpdateEvent(currentUpdateTime, success, millisForUpdate)
 				if e != nil {

--- a/trader/trader.go
+++ b/trader/trader.go
@@ -122,9 +122,9 @@ func (t *Trader) Start() {
 		if lastUpdateTime.IsZero() || t.timeController.ShouldUpdate(lastUpdateTime, currentUpdateTime) {
 			startUpdate := time.Now()
 			success := t.update()
-			updateDuration := time.Since(startUpdate)
+			millisForUpdate := time.Since(startUpdate)
 			e := t.threadTracker.TriggerGoroutine(func(inputs []interface{}) {
-				e := t.metricsTracker.SendUpdateEvent(currentUpdateTime, success, updateDuration.Milliseconds())
+				e := t.metricsTracker.SendUpdateEvent(currentUpdateTime, success, millisForUpdate.Milliseconds())
 				if e != nil {
 					log.Printf("failed to send update event metric: %s", e)
 				}

--- a/trader/trader.go
+++ b/trader/trader.go
@@ -122,9 +122,9 @@ func (t *Trader) Start() {
 		if lastUpdateTime.IsZero() || t.timeController.ShouldUpdate(lastUpdateTime, currentUpdateTime) {
 			startUpdate := time.Now()
 			success := t.update()
-			millisForUpdate := time.Since(startUpdate)
+			millisForUpdate := time.Since(startUpdate).Milliseconds()
 			e := t.threadTracker.TriggerGoroutine(func(inputs []interface{}) {
-				e := t.metricsTracker.SendUpdateEvent(currentUpdateTime, success, millisForUpdate.Milliseconds())
+				e := t.metricsTracker.SendUpdateEvent(currentUpdateTime, success, millisForUpdate)
 				if e != nil {
 					log.Printf("failed to send update event metric: %s", e)
 				}


### PR DESCRIPTION
This PR sends the duration of the update event along with the metrics' common prop. Part of #516.

After: Can see `millisForUpdate` in Amplitude Web UI for an event.
<img width="1098" alt="Screen Shot 2020-10-13 at 6 15 47 PM" src="https://user-images.githubusercontent.com/1740974/95932239-2d2f9480-0d80-11eb-94a9-8192ad9521cd.png">
