### PR TITLE
Use hashed trading account for metrics user ID (part of #516)

### DIFF
--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -731,7 +731,8 @@ func getUserID(l logger.Logger, botConfig trader.BotConfig) (string, error) {
 	if botConfig.IsTradingSdex() {
 		userIDPrehash = botConfig.TradingAccount()
 	} else {
-		userIDPrehash = amplitudeAPIKey
+		exchangeAPIKeys := botConfig.ExchangeAPIKeys.ToExchangeAPIKeys()
+		userIDPrehash = exchangeAPIKeys[0].Key
 	}
 
 	// hash avoids exposing the user account or api key

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -506,19 +506,11 @@ func runTradeCmd(options inputs) {
 	botConfig = convertDeprecatedBotConfigValues(l, botConfig)
 	l.Infof("Trading %s:%s for %s:%s\n", botConfig.AssetCodeA, botConfig.IssuerA, botConfig.AssetCodeB, botConfig.IssuerB)
 
-	var userIDPrehash string
-	if botConfig.IsTradingSdex() {
-		userIDPrehash = botConfig.TradingAccount()
-	} else {
-		userIDPrehash = amplitudeAPIKey
-	}
-
-	userIDHashed, e := utils.HashString(userIDPrehash)
+	userID, e := getUserID(l, botConfig)
 	if e != nil {
-		logger.Fatal(l, fmt.Errorf("could not create user id: %s", e))
+		logger.Fatal(l, fmt.Errorf("could not get user id: %s", e))
 	}
 
-	userID := fmt.Sprint(userIDHashed)
 	httpClient := &http.Client{}
 	var guiVersionFlag string
 	if *options.ui {
@@ -732,6 +724,25 @@ func runTradeCmd(options inputs) {
 
 	l.Info("Starting the trader bot...")
 	bot.Start()
+}
+
+func getUserID(l logger.Logger, botConfig trader.BotConfig) (string, error) {
+	var userIDPrehash string
+	if botConfig.IsTradingSdex() {
+		userIDPrehash = botConfig.TradingAccount()
+	} else {
+		userIDPrehash = amplitudeAPIKey
+	}
+
+	// hash avoids exposing the user account or api key
+	userIDHashed, e := utils.HashString(userIDPrehash)
+	if e != nil {
+		logger.Fatal(l, fmt.Errorf("could not create user id: %s", e))
+		return "", e
+	}
+
+	userID := fmt.Sprint(userIDHashed)
+	return userID, e
 }
 
 func startMonitoringServer(l logger.Logger, botConfig trader.BotConfig) error {

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -732,18 +732,20 @@ func getUserID(l logger.Logger, botConfig trader.BotConfig) (string, error) {
 		userIDPrehash = botConfig.TradingAccount()
 	} else {
 		exchangeAPIKeys := botConfig.ExchangeAPIKeys.ToExchangeAPIKeys()
+		if len(exchangeAPIKeys) == 0 {
+			return "", fmt.Errorf("could not find exchange API key on bot config")
+		}
+
 		userIDPrehash = exchangeAPIKeys[0].Key
 	}
 
 	// hash avoids exposing the user account or api key
 	userIDHashed, e := utils.HashString(userIDPrehash)
 	if e != nil {
-		logger.Fatal(l, fmt.Errorf("could not create user id: %s", e))
-		return "", e
+		return "", fmt.Errorf("could not create user id: %s", e)
 	}
 
-	userID := fmt.Sprint(userIDHashed)
-	return userID, e
+	return fmt.Sprint(userIDHashed), nil
 }
 
 func startMonitoringServer(l logger.Logger, botConfig trader.BotConfig) error {

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -506,7 +506,19 @@ func runTradeCmd(options inputs) {
 	botConfig = convertDeprecatedBotConfigValues(l, botConfig)
 	l.Infof("Trading %s:%s for %s:%s\n", botConfig.AssetCodeA, botConfig.IssuerA, botConfig.AssetCodeB, botConfig.IssuerB)
 
-	userID := "-1" // TODO DS Properly generate and save user ID.
+	var userIDPrehash string
+	if botConfig.IsTradingSdex() {
+		userIDPrehash = botConfig.TradingAccount()
+	} else {
+		userIDPrehash = amplitudeAPIKey
+	}
+
+	userIDHashed, e := utils.HashString(userIDPrehash)
+	if e != nil {
+		logger.Fatal(l, fmt.Errorf("could not create user id: %s", e))
+	}
+
+	userID := fmt.Sprint(userIDHashed)
 	httpClient := &http.Client{}
 	var guiVersionFlag string
 	if *options.ui {

--- a/support/sdk/ccxt.go
+++ b/support/sdk/ccxt.go
@@ -3,7 +3,6 @@ package sdk
 import (
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
 	"log"
 	"net/http"
 	"reflect"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/support/networking"
+	"github.com/stellar/kelp/support/utils"
 )
 
 // ccxtBaseURL should not have suffix of '/'
@@ -182,20 +182,11 @@ func makeInstanceName(exchangeName string, apiKey api.ExchangeAPIKey) (string, e
 		return exchangeName, nil
 	}
 
-	number, e := hashString(apiKey.Key)
+	number, e := utils.HashString(apiKey.Key)
 	if e != nil {
 		return "", fmt.Errorf("could not hash apiKey.Key: %s", e)
 	}
 	return fmt.Sprintf("%s%d", exchangeName, number), nil
-}
-
-func hashString(s string) (uint32, error) {
-	h := fnv.New32a()
-	_, e := h.Write([]byte(s))
-	if e != nil {
-		return 0, fmt.Errorf("error while hashing string: %s", e)
-	}
-	return h.Sum32(), nil
 }
 
 func (c *Ccxt) hasInstance(instanceList []string) bool {

--- a/support/sdk/ccxt_test.go
+++ b/support/sdk/ccxt_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
+	"github.com/stellar/kelp/support/utils"
 )
 
 func TestHashString(t *testing.T) {
@@ -28,7 +29,7 @@ func TestHashString(t *testing.T) {
 
 	for _, kase := range testCases {
 		t.Run(kase.s, func(t *testing.T) {
-			result, e := hashString(kase.s)
+			result, e := utils.HashString(kase.s)
 			if !assert.Nil(t, e) {
 				return
 			}

--- a/support/utils/functions.go
+++ b/support/utils/functions.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"log"
 	"math/big"
 	"math/rand"
@@ -417,4 +418,14 @@ func Offer2TxnBuildSellOffer(offer hProtocol.Offer) txnbuild.ManageSellOffer {
 		Price:   offer.Price,
 		OfferID: offer.ID,
 	}
+}
+
+// HashString hashes a string using the FNV-1 hash function.
+func HashString(s string) (uint32, error) {
+	h := fnv.New32a()
+	_, e := h.Write([]byte(s))
+	if e != nil {
+		return 0, fmt.Errorf("error while hashing string: %s", e)
+	}
+	return h.Sum32(), nil
 }


### PR DESCRIPTION
This PR uses the hash of the bot's trading account as the user ID for metrics collection. If the user is using a centralized exchange, then it uses the hash of the Amplitude API key. Part of #516.

After: We see a different integer as the User ID from those previously used, on a build from this branch.
<img width="976" alt="After: unique integer user id, from this branch" src="https://user-images.githubusercontent.com/1740974/95934974-fd37bf80-0d86-11eb-909a-4910630a58d9.png">
