### PR TITLE
Add version to metric event.

### DIFF
--- a/support/metrics/metricsTracker.go
+++ b/support/metrics/metricsTracker.go
@@ -40,6 +40,7 @@ type event struct {
 	SessionID int64       `json:"session_id"`
 	DeviceID  string      `json:"device_id"`
 	EventType string      `json:"event_type"`
+	Version   string      `json:"app_version"`
 	Props     interface{} `json:"event_properties"`
 }
 
@@ -191,6 +192,7 @@ func (mt *MetricsTracker) sendEvent(eventType string, eventProps interface{}) er
 			DeviceID:  mt.deviceID,
 			EventType: eventType,
 			Props:     eventProps,
+			Version:   mt.props.CliVersion,
 		}},
 	}
 	requestBody, e := json.Marshal(eventW)


### PR DESCRIPTION
This PR adds the `version` to the top-level metric event. Note that based on the [new API docs](https://help.amplitude.com/hc/en-us/articles/360032842391-HTTP-API-V2#tocSsuccesssummary), this requires serializing the `app_version` as the field in JSON. 

This shows the `version` surfaced in the web console:
<img width="835" alt="app_version shows up as Version" src="https://user-images.githubusercontent.com/1740974/96054879-81e21680-0e37-11eb-9171-509e0bf407d2.png">
