### PR TITLE
Add buy infrastructure to volume filter (part of #522)

### DIFF
--- a/examples/configs/trader/sample_buytwap.cfg
+++ b/examples/configs/trader/sample_buytwap.cfg
@@ -1,0 +1,120 @@
+# Sample config file for the "buy twap" strategy
+
+# This strategy requires the database and the fill handler to be enabled in the trader.cfg file
+
+# We are buying the base asset here, i.e. ASSET_CODE_A as defined in the trader config
+
+# Price Feeds
+# Note: we take the value from the A feed and divide it by the value retrieved from the B feed below.
+# the type of feeds can be one of crypto, fiat, fixed, exchange, sdex, function.
+
+# specification of feed type "exchange"
+START_ASK_FEED_TYPE="exchange"
+# the specification of the A feed
+# the format is <exchange name>/<base-asset-code-defined-by-exchange>/<quote-asset-code-defined-by-exchange>/<modifier>
+# exchange name:
+#     use "kraken" or any of the ccxt-exchanges (run `kelp exchanges` for full list)
+#     examples: "kraken", "ccxt-kraken", "ccxt-binance", "ccxt-poloniex", "ccxt-bittrex"
+# base asset code defined by exchange:
+#     this is the asset code defined by the exchange for the asset whose price you want to fetch (base asset).
+#     this code can be retrieved from the exchange's website or from the ccxt manual for ccxt-based exchanges.
+# quote asset code defined by exchange:
+#     this is the asset code defined by the exchange for asset in which you want to quote the price (quote asset).
+#     this code can be retrieved from the exchange's website or from the ccxt manual for ccxt-based exchanges.
+# modifier:
+#     this is a modifier that can be included only for feed type "exchange".
+#     a modifier allows you to fetch the "mid" price, "ask" price, "bid" price, or "last" price for now.
+#     if left unspecified then this is defaulted to "mid" for backwards compatibility (until v2.0 is released) (LOH-2)
+# uncomment below to use binance, poloniex, or bittrex as your price feed. You will need to set up CCXT to use this, see the "Using CCXT" section in the README for details.
+# be careful about using USD vs. USDT since some exchanges support only one, or both, or in some cases neither.
+#DATA_FEED_A_URL="ccxt-kraken/XLM/USD/last"
+#DATA_FEED_A_URL="ccxt-binance/XLM/USDT/ask"
+#DATA_FEED_A_URL="ccxt-poloniex/XLM/USDT/bid"
+# bittrex does not have an XLM/USD market so this config lists XLM/BTC instead; you should NOT use this when trying to price an asset based on the XLM/USD price (unless you know what you are doing).
+#DATA_FEED_A_URL="ccxt-bittrex/XLM/BTC"
+START_ASK_FEED_URL="kraken/XXLM/ZUSD/mid"
+
+# sample priceFeed with the "crypto" type
+#DATA_TYPE_A="crypto"
+# this is the URL to a coinmarketcap feed which the bot understands.
+#DATA_FEED_A_URL="https://api.coinmarketcap.com/v1/ticker/stellar/"
+
+# sample priceFeed with the "sdex" type
+# this feed pulls from the SDEX, you can use the asset you're trading or something else, like the same coin from another issuer
+# DATA_TYPE_A = "sdex"
+# this is a string representing a SDEX pair; the format is CODE:ISSUER/CODE:ISSUER
+# for XLM leave the issuer string blank
+# DATA_FEED_A_URL="COUPON:GBMMZMK2DC4FFP4CAI6KCVNCQ7WLO5A7DQU7EC7WGHRDQBZB763X4OQI/XLM:"
+
+# sample priceFeed of type "function"
+# this feed type uses one of the pre-defined functions to recursively operate on other price feeds
+# all URLs for this type of feed are formatted like so: function_name(feed_type/feed_url[,feed_type/feed_url])
+#DATA_TYPE_A = "function"
+# the supported functions for now are only the "max" and "invert" functions, example usage:
+#    "max": max(exchange/ccxt-kraken/XLM/USD/mid,exchange/ccxt-binance/XLM/USDT/mid) -- will give you the larger price
+#           between kraken's mid price and binance's mid price
+#    "invert": invert(exchange/ccxt-kraken/XLM/USD/mid) -- will give you the effective USD/XLM price
+#DATA_FEED_A_URL = "max(exchange/ccxt-kraken/XLM/USD/mid,exchange/ccxt-binance/XLM/USDT/mid)"
+
+# what value of a price change triggers re-creating an offer. Price change refers to the existing price of the offer vs. what price we want to set. value is a percentage specified as a decimal number (0 < value < 1.00)
+PRICE_TOLERANCE=0.001
+
+# what value of an amount change triggers re-creating an offer. Amount change refers to the existing amount of the offer vs. what amount we want to set. value is a percentage specified as a decimal number (0 < value < 1.00)
+AMOUNT_TOLERANCE=0.001
+
+# how much percent to offset your rates by, specified as a decimal (ex: 0.05 = 5%). Can be used in conjunction with RATE_OFFSET below.
+# A positive value indicates that your base asset (ASSET_A) has a higher rate than the rate received from your price feed
+# A negative value indicates that your base asset (ASSET_A) has a lower rate than the rate received from your price feed
+RATE_OFFSET_PERCENT=0.0
+# how much to offset your rates by, specified in number of units of the quote asset (ASSET_B) as a decimal.
+# Can be used in conjunction with RATE_OFFSET_PERCENT above.
+# A positive value indicates that your base asset (ASSET_A) has a higher rate than the rate received from your price feed
+# A negative value indicates that your base asset (ASSET_A) has a lower rate than the rate received from your price feed
+RATE_OFFSET=0.0
+# specifies the order in which to offset the rates. If true then we apply the RATE_OFFSET_PERCENT first otherwise we apply the RATE_OFFSET first
+# example rate calculation when set to true: ((rate_from_price_feed_a/rate_from_price_feed_b) * (1 + rate_offset_percent)) + rate_offset
+# example rate calculation when set to false: ((rate_from_price_feed_a/rate_from_price_feed_b) + rate_offset) * (1 + rate_offset_percent)
+RATE_OFFSET_PERCENT_FIRST=true
+
+# NUM_HOURS_TO_SELL is an integer that defines the number of hours in which to complete the sales
+# It is actually the number of hours to buy, but is called "SELL" for compatibility with pre-existing data structures
+NUM_HOURS_TO_SELL = 23
+
+# PARENT_BUCKET_SIZE_SECONDS is an integer value which represents the number of seconds to count as a single parent bucket.
+# this should perfectly divide the number of seconds in a day (24 * 60 * 60)
+# TODO how does this handle leap days?
+PARENT_BUCKET_SIZE_SECONDS = 600
+
+# DISTRIBUTE_SURPLUS_OVER_REMAINING_INTERVALS_PERCENT_CEILING is specified as a decimal value from 0.0-1.0 inclusive.
+# we take the percent of remaining bucket intervals (ceiling of that number) to arrive at the number of intervals over which to distribute the surplus.
+# ceiling(4.5) = 5
+# ceiling(5.1) = 6
+# example: a value of 0.05 here will distribute the surplus over 1/20th of the remaining bucket intervals
+# if there are 345 bucket intervals remaining and this value is set to 0.05, the bot will use this calculation:
+#    ceiling(0.05 * 345)
+#    = ceiling(17.25)
+#    = 17 buckets over which to distribute the excess surplus
+# therefore, the bot will distribute the surplus over the remaining 17 bucket intervals (of total 345 bucket intervals)
+# Note that setting this to 0.0 will discard any surplus and setting it to 1.0 will distribute over all remaining bucket intervals
+DISTRIBUTE_SURPLUS_OVER_REMAINING_INTERVALS_PERCENT_CEILING = 0.05
+
+# EXPONENTIAL_SMOOTHING_FACTOR is a decimal (0 <= x <= 1)
+# a larger number results in a smoother distribution across the remaining intervals
+# set this to 1.0 for a linear distribution over the chosen bucket intervals and 0.0 to buy the entire surplus in the next bucket interval
+EXPONENTIAL_SMOOTHING_FACTOR = 0.50
+
+# MIN_CHILD_ORDER_SIZE_PERCENT_OF_PARENT is a decimal value (0 <= x <= 1) which defines the lower bound of the randomization function to be
+# used when picking the size of the order to be placed in a bot update cycle. The randomized number is then multiplied by the total capacity
+# for the current bucket interval. If the available capacity for the interval is less than this amount then we will use the available capacity.
+MIN_CHILD_ORDER_SIZE_PERCENT_OF_PARENT = 0.2
+
+# DAY_OF_WEEK_DAILY_CAP is a volume filter specified individually for every day of the week
+# make sure any filters in your trader.cfg file is compliant with this configuration
+[DAY_OF_WEEK_DAILY_CAP]
+Mo = "volume/daily/buy/base/10000.0/exact"
+Tu = "volume/daily/buy/base/10000.0/exact"
+We = "volume/daily/buy/base/10000.0/exact"
+Th = "volume/daily/buy/base/10000.0/exact"
+Fr = "volume/daily/buy/base/10000.0/exact"
+Sa = "volume/daily/buy/base/10000.0/exact"
+Su = "volume/daily/buy/base/10000.0/exact"

--- a/plugins/filterFactory.go
+++ b/plugins/filterFactory.go
@@ -9,6 +9,7 @@ import (
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
 	"github.com/stellar/kelp/model"
+	"github.com/stellar/kelp/queries"
 )
 
 var filterIDRegex *regexp.Regexp
@@ -88,6 +89,12 @@ func makeVolumeFilterConfig(configInput string) (*VolumeFilterConfig, error) {
 		return nil, fmt.Errorf("invalid input (%s), the second part needs to equal or start with \"daily\"", configInput)
 	}
 
+	action, e := queries.ParseDailyVolumeAction(parts[2])
+	if e != nil {
+		return nil, fmt.Errorf("could not parse volume filter action from input (%s): %s", configInput, e)
+	}
+	config.action = action
+
 	errInvalid := fmt.Errorf("invalid input (%s), the modifier for \"daily\" can be either \"market_ids\" or \"account_ids\" like so 'daily:market_ids=[4c19915f47,db4531d586]' or 'daily:account_ids=[account1,account2]' or 'daily:market_ids=[4c19915f47,db4531d586]:account_ids=[account1,account2]'", configInput)
 	if len(limitWindowParts) == 2 {
 		e = addModifierToConfig(config, limitWindowParts[1])
@@ -108,17 +115,14 @@ func makeVolumeFilterConfig(configInput string) (*VolumeFilterConfig, error) {
 		return nil, fmt.Errorf("invalid input (%s), the second part needs to be \"daily\" and can have only one modifier \"market_ids\" like so 'daily:market_ids=[4c19915f47,db4531d586]'", configInput)
 	}
 
-	if parts[2] != "sell" {
-		return nil, fmt.Errorf("invalid input (%s), the third part needs to be \"sell\"", configInput)
-	}
 	limit, e := strconv.ParseFloat(parts[4], 64)
 	if e != nil {
 		return nil, fmt.Errorf("could not parse the fourth part as a float value from config value (%s): %s", configInput, e)
 	}
 	if parts[3] == "base" {
-		config.SellBaseAssetCapInBaseUnits = &limit
+		config.BaseAssetCapInBaseUnits = &limit
 	} else if parts[3] == "quote" {
-		config.SellBaseAssetCapInQuoteUnits = &limit
+		config.BaseAssetCapInQuoteUnits = &limit
 	} else {
 		return nil, fmt.Errorf("invalid input (%s), the third part needs to be \"base\" or \"quote\"", configInput)
 	}

--- a/plugins/filterFactory_test.go
+++ b/plugins/filterFactory_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/openlyinc/pointy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/stellar/kelp/queries"
 )
 
 func TestParseIdsArray(t *testing.T) {
@@ -136,49 +138,74 @@ func TestMakeVolumeFilterConfig(t *testing.T) {
 		wantConfig  *VolumeFilterConfig
 	}{
 		{
+			configInput: "volume/daily/buy/base/3500.0/exact",
+			wantConfig: &VolumeFilterConfig{
+				BaseAssetCapInBaseUnits:  pointy.Float64(3500.0),
+				BaseAssetCapInQuoteUnits: nil,
+				mode:                     volumeFilterModeExact,
+				action:                   queries.DailyVolumeActionBuy,
+				additionalMarketIDs:      nil,
+				optionalAccountIDs:       nil,
+			},
+		}, {
+			configInput: "volume/daily/buy/quote/4000.0/exact",
+			wantConfig: &VolumeFilterConfig{
+				BaseAssetCapInBaseUnits:  nil,
+				BaseAssetCapInQuoteUnits: pointy.Float64(4000.0),
+				mode:                     volumeFilterModeExact,
+				action:                   queries.DailyVolumeActionBuy,
+				additionalMarketIDs:      nil,
+				optionalAccountIDs:       nil,
+			},
+		}, {
 			configInput: "volume/daily/sell/base/3500.0/exact",
 			wantConfig: &VolumeFilterConfig{
-				SellBaseAssetCapInBaseUnits:  pointy.Float64(3500.0),
-				SellBaseAssetCapInQuoteUnits: nil,
-				mode:                         volumeFilterModeExact,
-				additionalMarketIDs:          nil,
-				optionalAccountIDs:           nil,
+				BaseAssetCapInBaseUnits:  pointy.Float64(3500.0),
+				BaseAssetCapInQuoteUnits: nil,
+				mode:                     volumeFilterModeExact,
+				action:                   queries.DailyVolumeActionSell,
+				additionalMarketIDs:      nil,
+				optionalAccountIDs:       nil,
 			},
 		}, {
 			configInput: "volume/daily/sell/quote/1000.0/ignore",
 			wantConfig: &VolumeFilterConfig{
-				SellBaseAssetCapInBaseUnits:  nil,
-				SellBaseAssetCapInQuoteUnits: pointy.Float64(1000.0),
-				mode:                         volumeFilterModeIgnore,
-				additionalMarketIDs:          nil,
-				optionalAccountIDs:           nil,
+				BaseAssetCapInBaseUnits:  nil,
+				BaseAssetCapInQuoteUnits: pointy.Float64(1000.0),
+				mode:                     volumeFilterModeIgnore,
+				action:                   queries.DailyVolumeActionSell,
+				additionalMarketIDs:      nil,
+				optionalAccountIDs:       nil,
 			},
 		}, {
 			configInput: "volume/daily:market_ids=[4c19915f47,db4531d586]/sell/base/3500.0/exact",
 			wantConfig: &VolumeFilterConfig{
-				SellBaseAssetCapInBaseUnits:  pointy.Float64(3500.0),
-				SellBaseAssetCapInQuoteUnits: nil,
-				mode:                         volumeFilterModeExact,
-				additionalMarketIDs:          []string{"4c19915f47", "db4531d586"},
-				optionalAccountIDs:           nil,
+				BaseAssetCapInBaseUnits:  pointy.Float64(3500.0),
+				BaseAssetCapInQuoteUnits: nil,
+				mode:                     volumeFilterModeExact,
+				action:                   queries.DailyVolumeActionSell,
+				additionalMarketIDs:      []string{"4c19915f47", "db4531d586"},
+				optionalAccountIDs:       nil,
 			},
 		}, {
 			configInput: "volume/daily:account_ids=[account1,account2]/sell/base/3500.0/exact",
 			wantConfig: &VolumeFilterConfig{
-				SellBaseAssetCapInBaseUnits:  pointy.Float64(3500.0),
-				SellBaseAssetCapInQuoteUnits: nil,
-				mode:                         volumeFilterModeExact,
-				additionalMarketIDs:          nil,
-				optionalAccountIDs:           []string{"account1", "account2"},
+				BaseAssetCapInBaseUnits:  pointy.Float64(3500.0),
+				BaseAssetCapInQuoteUnits: nil,
+				mode:                     volumeFilterModeExact,
+				action:                   queries.DailyVolumeActionSell,
+				additionalMarketIDs:      nil,
+				optionalAccountIDs:       []string{"account1", "account2"},
 			},
 		}, {
 			configInput: "volume/daily:market_ids=[4c19915f47,db4531d586]:account_ids=[account1,account2]/sell/base/3500.0/exact",
 			wantConfig: &VolumeFilterConfig{
-				SellBaseAssetCapInBaseUnits:  pointy.Float64(3500.0),
-				SellBaseAssetCapInQuoteUnits: nil,
-				mode:                         volumeFilterModeExact,
-				additionalMarketIDs:          []string{"4c19915f47", "db4531d586"},
-				optionalAccountIDs:           []string{"account1", "account2"},
+				BaseAssetCapInBaseUnits:  pointy.Float64(3500.0),
+				BaseAssetCapInQuoteUnits: nil,
+				mode:                     volumeFilterModeExact,
+				action:                   queries.DailyVolumeActionSell,
+				additionalMarketIDs:      []string{"4c19915f47", "db4531d586"},
+				optionalAccountIDs:       []string{"account1", "account2"},
 			},
 		},
 	}
@@ -200,9 +227,10 @@ func assertVolumeFilterConfigEqual(t *testing.T, want *VolumeFilterConfig, actua
 	} else if actual == nil {
 		assert.Fail(t, fmt.Sprintf("actual was nil but expected %v", *want))
 	} else {
-		assert.Equal(t, want.SellBaseAssetCapInBaseUnits, actual.SellBaseAssetCapInBaseUnits)
-		assert.Equal(t, want.SellBaseAssetCapInQuoteUnits, actual.SellBaseAssetCapInQuoteUnits)
+		assert.Equal(t, want.BaseAssetCapInBaseUnits, actual.BaseAssetCapInBaseUnits)
+		assert.Equal(t, want.BaseAssetCapInQuoteUnits, actual.BaseAssetCapInQuoteUnits)
 		assert.Equal(t, want.mode, actual.mode)
+		assert.Equal(t, want.action, actual.action)
 		assert.Equal(t, want.additionalMarketIDs, actual.additionalMarketIDs)
 		assert.Equal(t, want.optionalAccountIDs, actual.optionalAccountIDs)
 	}

--- a/queries/dailyVolumeByDate.go
+++ b/queries/dailyVolumeByDate.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/stellar/kelp/api"
+	"github.com/stellar/kelp/support/utils"
 )
 
 // sqlQueryDailyValuesTemplateAllAccounts queries the trades table to get the values for a given day
@@ -37,6 +38,7 @@ func MakeDailyVolumeByDateForMarketIdsAction(
 	optionalAccountIDs []string,
 ) (*DailyVolumeByDate, error) {
 	if db == nil {
+		utils.PrintErrorHintf("the provided POSTGRES_DB config in the trader.cfg file should be non-nil")
 		return nil, fmt.Errorf("the provided db should be non-nil")
 	}
 

--- a/queries/dailyVolumeByDate_test.go
+++ b/queries/dailyVolumeByDate_test.go
@@ -39,6 +39,7 @@ func connectTestDb() *sql.DB {
 
 func TestDailyVolumeByDate_QueryRow(t *testing.T) {
 	testCases := []struct {
+		action                    DailyVolumeAction
 		queryByOptionalAccountIDs []string
 		wantYesterdayBase         float64
 		wantYesterdayQuote        float64
@@ -48,6 +49,17 @@ func TestDailyVolumeByDate_QueryRow(t *testing.T) {
 		wantTomorrowQuote         float64
 	}{
 		{
+			// TODO add case for buy base/quote and add trade data in test below accordingly
+			// 	action:                    DailyVolumeActionBuy,
+			// 	queryByOptionalAccountIDs: []string{}, // accountID1 and accountID2 are the only ones that exists
+			// 	wantYesterdayBase:         100.0,
+			// 	wantYesterdayQuote:        10.0,
+			// 	wantTodayBase:             207.0,
+			// 	wantTodayQuote:            21.83,
+			// 	wantTomorrowBase:          102.0,
+			// 	wantTomorrowQuote:         12.24,
+			// }, {
+			action:                    DailyVolumeActionSell,
 			queryByOptionalAccountIDs: []string{}, // accountID1 and accountID2 are the only ones that exists
 			wantYesterdayBase:         100.0,
 			wantYesterdayQuote:        10.0,
@@ -56,6 +68,7 @@ func TestDailyVolumeByDate_QueryRow(t *testing.T) {
 			wantTomorrowBase:          102.0,
 			wantTomorrowQuote:         12.24,
 		}, {
+			action:                    DailyVolumeActionSell,
 			queryByOptionalAccountIDs: []string{"accountID1", "accountID2"}, // accountID1 and accountID2 are the only ones that exists
 			wantYesterdayBase:         100.0,
 			wantYesterdayQuote:        10.0,
@@ -64,6 +77,7 @@ func TestDailyVolumeByDate_QueryRow(t *testing.T) {
 			wantTomorrowBase:          102.0,
 			wantTomorrowQuote:         12.24,
 		}, {
+			action:                    DailyVolumeActionSell,
 			queryByOptionalAccountIDs: []string{"accountID1"}, // accountID1 has most of the entries
 			wantYesterdayBase:         100.0,
 			wantYesterdayQuote:        10.0,
@@ -72,6 +86,7 @@ func TestDailyVolumeByDate_QueryRow(t *testing.T) {
 			wantTomorrowBase:          102.0,
 			wantTomorrowQuote:         12.24,
 		}, {
+			action:                    DailyVolumeActionSell,
 			queryByOptionalAccountIDs: []string{"accountID2"}, //accountID2 has only one entry, which is for today
 			wantYesterdayBase:         0.0,
 			wantYesterdayQuote:        0.0,
@@ -80,6 +95,7 @@ func TestDailyVolumeByDate_QueryRow(t *testing.T) {
 			wantTomorrowBase:          0.0,
 			wantTomorrowQuote:         0.0,
 		}, {
+			action:                    DailyVolumeActionSell,
 			queryByOptionalAccountIDs: []string{"accountID3"}, //accountID3 does not exist
 			wantYesterdayBase:         0.0,
 			wantYesterdayQuote:        0.0,
@@ -196,7 +212,7 @@ func TestDailyVolumeByDate_QueryRow(t *testing.T) {
 			dailyVolumeByDateQuery, e := MakeDailyVolumeByDateForMarketIdsAction(
 				db,
 				[]string{"market1"},
-				"sell",
+				k.action,
 				k.queryByOptionalAccountIDs,
 			)
 			if !assert.NoError(t, e) {

--- a/queries/strategyMirrorTradeTriggerExists.go
+++ b/queries/strategyMirrorTradeTriggerExists.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/stellar/kelp/api"
+	"github.com/stellar/kelp/support/utils"
 )
 
 // sqlQueryStrategyMirrorTradeTriggerExists queries the strategy_mirror_trade_triggers table by market_id and txid (primary key) to see if the row exists
@@ -23,6 +24,7 @@ var _ api.Query = &StrategyMirrorTradeTriggerExists{}
 // MakeStrategyMirrorTradeTriggerExists makes the StrategyMirrorTradeTriggerExists query
 func MakeStrategyMirrorTradeTriggerExists(db *sql.DB, marketID string) (*StrategyMirrorTradeTriggerExists, error) {
 	if db == nil {
+		utils.PrintErrorHintf("the provided POSTGRES_DB config in the trader.cfg file should be non-nil")
 		return nil, fmt.Errorf("the provided db should be non-nil")
 	}
 


### PR DESCRIPTION
This PR adds the buy infrastructure to the volume filter, as per step 2 [here](https://github.com/stellar/kelp/pull/548#issuecomment-712792629).

This is marked as a draft PR, because the new test in `TestDailyVolumeByDate_QueryRow` does not yet work.