### PR TITLE
Add missing CLI metrics from inputs (part of #551)

### DIFF
--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -538,8 +538,8 @@ func runTradeCmd(options inputs) {
 		env,
 		runtime.GOOS,
 		runtime.GOARCH,
-		runtime.Version(),
 		"unknown_todo", // TODO DS Determine how to get GOARM.
+		runtime.Version(),
 		guiVersionFlag,
 		*options.strategy,
 		botConfig.TickIntervalSeconds,
@@ -559,10 +559,10 @@ func runTradeCmd(options inputs) {
 		int(botConfig.MonitoringPort) != 0,
 		len(botConfig.Filters) > 0,
 		botConfig.PostgresDbConfig != nil,
+		*options.logPrefix != "",
 		*options.operationalBuffer,
 		*options.operationalBufferNonNativePct,
 		*options.simMode,
-		*options.logPrefix,
 		*options.fixedIterations,
 	)
 	if e != nil {

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -538,6 +538,7 @@ func runTradeCmd(options inputs) {
 		env,
 		runtime.GOOS,
 		runtime.GOARCH,
+		runtime.Version(),
 		"unknown_todo", // TODO DS Determine how to get GOARM.
 		guiVersionFlag,
 		*options.strategy,
@@ -558,6 +559,11 @@ func runTradeCmd(options inputs) {
 		int(botConfig.MonitoringPort) != 0,
 		len(botConfig.Filters) > 0,
 		botConfig.PostgresDbConfig != nil,
+		*options.operationalBuffer,
+		*options.operationalBufferNonNativePct,
+		*options.simMode,
+		*options.logPrefix,
+		*options.fixedIterations,
 	)
 	if e != nil {
 		logger.Fatal(l, fmt.Errorf("could not generate metrics tracker: %s", e))

--- a/support/metrics/metricsTracker.go
+++ b/support/metrics/metricsTracker.go
@@ -76,10 +76,10 @@ type commonProps struct {
 	EnabledFeatureMonitoring         bool    `json:"enabled_feature_monitoring"`
 	EnabledFeatureFilters            bool    `json:"enabled_feature_filters"`
 	EnabledFeaturePostgres           bool    `json:"enabled_feature_postgres"`
+	EnabledFeatureLogging            bool    `json:"enabled_feature_logging"`
 	OperationalBuffer                float64 `json:"operational_buffer"`
 	OperationalBufferNonNativePct    float64 `json:"operational_buffer_non_native_pct"`
 	SimMode                          bool    `json:"sim_mode"`
-	LogPrefix                        string  `json:"log_prefix"`
 	FixedIterations                  uint64  `json:"fixed_iterations"`
 }
 
@@ -157,10 +157,10 @@ func MakeMetricsTracker(
 	enabledFeatureMonitoring bool,
 	enabledFeatureFilters bool,
 	enabledFeaturePostgres bool,
+	enabledFeatureLogging bool,
 	operationalBuffer float64,
 	operationalBufferNonNativePct float64,
 	simMode bool,
-	logPrefix string,
 	fixedIterations uint64,
 ) (*MetricsTracker, error) {
 	props := commonProps{
@@ -189,10 +189,10 @@ func MakeMetricsTracker(
 		EnabledFeatureMonitoring:         enabledFeatureMonitoring,
 		EnabledFeatureFilters:            enabledFeatureFilters,
 		EnabledFeaturePostgres:           enabledFeaturePostgres,
+		EnabledFeatureLogging:            enabledFeatureLogging,
 		OperationalBuffer:                operationalBuffer,
 		OperationalBufferNonNativePct:    operationalBufferNonNativePct,
 		SimMode:                          simMode,
-		LogPrefix:                        logPrefix,
 		FixedIterations:                  fixedIterations,
 	}
 

--- a/support/metrics/metricsTracker.go
+++ b/support/metrics/metricsTracker.go
@@ -56,6 +56,7 @@ type commonProps struct {
 	Goos                             string  `json:"goos"`
 	Goarch                           string  `json:"goarch"`
 	Goarm                            string  `json:"goarm"`
+	GoVersion                        string  `json:"go_version"`
 	GuiVersion                       string  `json:"gui_version"`
 	Strategy                         string  `json:"strategy"`
 	UpdateTimeIntervalSeconds        int32   `json:"update_time_interval_seconds"`
@@ -75,6 +76,11 @@ type commonProps struct {
 	EnabledFeatureMonitoring         bool    `json:"enabled_feature_monitoring"`
 	EnabledFeatureFilters            bool    `json:"enabled_feature_filters"`
 	EnabledFeaturePostgres           bool    `json:"enabled_feature_postgres"`
+	OperationalBuffer                float64 `json:"operational_buffer"`
+	OperationalBufferNonNativePct    float64 `json:"operational_buffer_non_native_pct"`
+	SimMode                          bool    `json:"sim_mode"`
+	LogPrefix                        string  `json:"log_prefix"`
+	FixedIterations                  uint64  `json:"fixed_iterations"`
 }
 
 // updateProps holds the properties for the update Amplitude event.
@@ -131,6 +137,7 @@ func MakeMetricsTracker(
 	goos string,
 	goarch string,
 	goarm string,
+	goVersion string,
 	guiVersion string,
 	strategy string,
 	updateTimeIntervalSeconds int32,
@@ -150,6 +157,11 @@ func MakeMetricsTracker(
 	enabledFeatureMonitoring bool,
 	enabledFeatureFilters bool,
 	enabledFeaturePostgres bool,
+	operationalBuffer float64,
+	operationalBufferNonNativePct float64,
+	simMode bool,
+	logPrefix string,
+	fixedIterations uint64,
 ) (*MetricsTracker, error) {
 	props := commonProps{
 		CliVersion:                       version,
@@ -158,6 +170,7 @@ func MakeMetricsTracker(
 		Goos:                             goos,
 		Goarch:                           goarch,
 		Goarm:                            goarm,
+		GoVersion:                        goVersion,
 		GuiVersion:                       guiVersion,
 		Strategy:                         strategy,
 		UpdateTimeIntervalSeconds:        updateTimeIntervalSeconds,
@@ -176,6 +189,11 @@ func MakeMetricsTracker(
 		EnabledFeatureMonitoring:         enabledFeatureMonitoring,
 		EnabledFeatureFilters:            enabledFeatureFilters,
 		EnabledFeaturePostgres:           enabledFeaturePostgres,
+		OperationalBuffer:                operationalBuffer,
+		OperationalBufferNonNativePct:    operationalBufferNonNativePct,
+		SimMode:                          simMode,
+		LogPrefix:                        logPrefix,
+		FixedIterations:                  fixedIterations,
 	}
 
 	return &MetricsTracker{


### PR DESCRIPTION
This PR adds some missing metrics to the CLI data tracking, using already-inputted values from the command line. This is part of #551. 

Subsequent PRs will add counters for the various metric events; hardware-based characteristics; and, later, a network event.