### PR TITLE
network speedup: check markets cache for existing symbols in ccxt.go#symbolExists(), closes #559

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,18 @@ commands:
           name: Run Kelp tests
           command: go test --short -ldflags="-X github.com/stellar/kelp/cmd.version=test_compile -X github.com/stellar/kelp/cmd.guiVersion=test_compile -X github.com/stellar/kelp/cmd.gitBranch=test_compile -X github.com/stellar/kelp/cmd.gitHash=test_compile -X github.com/stellar/kelp/cmd.buildDate=test_compile -X github.com/stellar/kelp/cmd.env=dev" ./...
 
+  replace_trader_secret:
+    steps:
+      - run:
+          name: Replace Trader Secret
+          command: sed -i '' 's/SAOQ6IG2WWDEP47WEJNLIU27OBODMEWFDN6PVUR5KHYDOCVCL34J2CUD/SCNWRBLLRCPKKMFTDBU2JN6DWOLJ42FGOQHVF62FMXRQRI7HEERAAO2B/' examples/configs/trader/sample_trader.cfg
+
+  replace_source_secret:
+    steps:
+      - run:
+          name: Replace Source Secret
+          command: sed -i '' 's/SDDAHRX2JB663N3OLKZIBZPF33ZEKMHARX362S737JEJS2AX3GJZY5LU/SCNWRBLLRCPKKMFTDBU2JN6DWOLJ42FGOQHVF62FMXRQRI7HEERAAO2B/' examples/configs/trader/sample_trader.cfg
+
   test_kelp__integration_delete:
     steps:
       - run:
@@ -106,6 +118,8 @@ jobs:
       # don't list sell_twap strategy for now because it requires a db to be enabled in sample_trader.cfg
       - install_deps
       - build_kelp
+      - replace_trader_secret
+      - replace_source_secret
       # delete once before we start our set of tests, don't delete in between tests because of rate limit issues
       - test_kelp__integration_delete
       - test_kelp__integration_buysell

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,13 +59,13 @@ commands:
     steps:
       - run:
           name: Replace Trader Secret
-          command: sed -i '' 's/SAOQ6IG2WWDEP47WEJNLIU27OBODMEWFDN6PVUR5KHYDOCVCL34J2CUD/SCNWRBLLRCPKKMFTDBU2JN6DWOLJ42FGOQHVF62FMXRQRI7HEERAAO2B/' examples/configs/trader/sample_trader.cfg
+          command: sed -i -e 's/SAOQ6IG2WWDEP47WEJNLIU27OBODMEWFDN6PVUR5KHYDOCVCL34J2CUD/SCNWRBLLRCPKKMFTDBU2JN6DWOLJ42FGOQHVF62FMXRQRI7HEERAAO2B/' examples/configs/trader/sample_trader.cfg
 
   replace_source_secret:
     steps:
       - run:
           name: Replace Source Secret
-          command: sed -i '' 's/SDDAHRX2JB663N3OLKZIBZPF33ZEKMHARX362S737JEJS2AX3GJZY5LU/SCNWRBLLRCPKKMFTDBU2JN6DWOLJ42FGOQHVF62FMXRQRI7HEERAAO2B/' examples/configs/trader/sample_trader.cfg
+          command: sed -i -e 's/SDDAHRX2JB663N3OLKZIBZPF33ZEKMHARX362S737JEJS2AX3GJZY5LU/SCNWRBLLRCPKKMFTDBU2JN6DWOLJ42FGOQHVF62FMXRQRI7HEERAAO2B/' examples/configs/trader/sample_trader.cfg
 
   test_kelp__integration_delete:
     steps:

--- a/support/sdk/ccxt.go
+++ b/support/sdk/ccxt.go
@@ -226,6 +226,11 @@ func (c *Ccxt) newInstance(apiKey api.ExchangeAPIKey, params []api.ExchangeParam
 
 // symbolExists returns an error if the symbol does not exist
 func (c *Ccxt) symbolExists(tradingPair string) error {
+	if _, ok := c.markets[tradingPair]; ok {
+		log.Printf("found trading pair symbol '%s' in markets map", tradingPair)
+		return nil
+	}
+
 	// get list of symbols available on exchange
 	url := ccxtBaseURL + pathExchanges + "/" + c.exchangeName + "/" + c.instanceName
 	// decode generic data (see "https://blog.golang.org/json-and-go#TOC_4.")


### PR DESCRIPTION
improves mirror strategy by 20% (4.2s to 3.4s) and centralized exchange bots by a lot more