### PR TITLE
Add metrics for operation counts (part of #551)

### DIFF
--- a/api/exchange.go
+++ b/api/exchange.go
@@ -266,7 +266,13 @@ func ConvertOperation2TM(ops []txnbuild.Operation) []build.TransactionMutator {
 
 // ConvertTM2Operation is a temporary adapter to support transitioning from the old Go SDK to the new SDK without having to bump the major version
 func ConvertTM2Operation(muts []build.TransactionMutator) []txnbuild.Operation {
-	ops := []txnbuild.Operation{}
+	msos := ConvertTM2MSO(muts)
+	return ConvertMSO2Ops(msos)
+}
+
+// ConvertTM2MSO converts mutators from the old SDK to ManageSellOffer ops in the new one.
+func ConvertTM2MSO(muts []build.TransactionMutator) []*txnbuild.ManageSellOffer {
+	msos := []*txnbuild.ManageSellOffer{}
 	for _, m := range muts {
 		var mso *txnbuild.ManageSellOffer
 		if mob, ok := m.(build.ManageOfferBuilder); ok {
@@ -276,6 +282,15 @@ func ConvertTM2Operation(muts []build.TransactionMutator) []txnbuild.Operation {
 		} else {
 			panic(fmt.Sprintf("could not convert build.TransactionMutator to txnbuild.Operation: %v (type=%T)\n", m, m))
 		}
+		msos = append(msos, mso)
+	}
+	return msos
+}
+
+// ConvertMSO2Ops converts manage sell offers into Operations.
+func ConvertMSO2Ops(msos []*txnbuild.ManageSellOffer) []txnbuild.Operation {
+	ops := []txnbuild.Operation{}
+	for _, mso := range msos {
 		ops = append(ops, mso)
 	}
 	return ops

--- a/plugins/metricsTracker.go
+++ b/plugins/metricsTracker.go
@@ -92,8 +92,8 @@ type updateProps struct {
 	MillisForUpdate              int64   `json:"millis_for_update"`
 	SecondsSinceLastUpdateMetric float64 `json:"seconds_since_last_update_metric"` // helps understand total runtime of bot when summing this field across events
 	NumPruneOps                  int     `json:"num_prune_ops"`
-	NumUpdatesOpsDelete          int     `json:"num_update_ops_delete"`
-	NumUpdatesOpsUpdate          int     `json:"num_update_ops_update"`
+	NumUpdateOpsDelete           int     `json:"num_update_ops_delete"`
+	NumUpdateOpsUpdate           int     `json:"num_update_ops_update"`
 	NumUpdateOpsCreate           int     `json:"num_update_ops_create"`
 }
 
@@ -300,8 +300,8 @@ func (mt *MetricsTracker) SendUpdateEvent(now time.Time, updateResult UpdateLoop
 		MillisForUpdate:              millisForUpdate,
 		SecondsSinceLastUpdateMetric: secondsSinceLastUpdateMetric,
 		NumPruneOps:                  updateResult.NumPruneOps,
-		NumUpdatesOpsDelete:          updateResult.NumUpdateOpsDelete,
-		NumUpdatesOpsUpdate:          updateResult.NumUpdateOpsUpdate,
+		NumUpdateOpsDelete:           updateResult.NumUpdateOpsDelete,
+		NumUpdateOpsUpdate:           updateResult.NumUpdateOpsUpdate,
 		NumUpdateOpsCreate:           updateResult.NumUpdateOpsCreate,
 	}
 

--- a/plugins/metricsTracker.go
+++ b/plugins/metricsTracker.go
@@ -94,6 +94,7 @@ type updateProps struct {
 	NumPruneOps                  int     `json:"num_prune_ops"`
 	NumUpdatesOpsDelete          int     `json:"num_update_ops_delete"`
 	NumUpdatesOpsUpdate          int     `json:"num_update_ops_update"`
+	NumUpdateOpsCreate           int     `json:"num_update_ops_create"`
 }
 
 // deleteProps holds the properties for the delete Amplitude event.
@@ -115,6 +116,7 @@ type UpdateLoopResult struct {
 	NumPruneOps        int
 	NumUpdateOpsDelete int
 	NumUpdateOpsUpdate int
+	NumUpdateOpsCreate int
 }
 
 // response structure taken from here: https://help.amplitude.com/hc/en-us/articles/360032842391-HTTP-API-V2#tocSsuccesssummary
@@ -299,6 +301,7 @@ func (mt *MetricsTracker) SendUpdateEvent(now time.Time, updateResult UpdateLoop
 		NumPruneOps:                  updateResult.NumPruneOps,
 		NumUpdatesOpsDelete:          updateResult.NumUpdateOpsDelete,
 		NumUpdatesOpsUpdate:          updateResult.NumUpdateOpsUpdate,
+		NumUpdateOpsCreate:           updateResult.NumUpdateOpsCreate,
 	}
 
 	e := mt.SendEvent(updateEventName, updateProps, now)
@@ -322,10 +325,10 @@ func (mt *MetricsTracker) SendDeleteEvent(exit bool) error {
 
 // SendEvent sends an event with its type and properties to Amplitude.
 func (mt *MetricsTracker) SendEvent(eventType string, eventPropsInterface interface{}, now time.Time) error {
-	if mt.apiKey == "" || mt.userID == "-1" || mt.isDisabled {
-		log.Printf("metric - not sending event metric of type '%s' because metrics are disabled", eventType)
-		return nil
-	}
+	// if mt.apiKey == "" || mt.userID == "-1" || mt.isDisabled {
+	// 	log.Printf("metric - not sending event metric of type '%s' because metrics are disabled", eventType)
+	// 	return nil
+	// }
 
 	trackerProps := mt.props
 	trackerProps[secondsSinceStartKey] = now.Sub(mt.botStartTime).Seconds()

--- a/plugins/metricsTracker.go
+++ b/plugins/metricsTracker.go
@@ -111,6 +111,7 @@ type eventWrapper struct {
 }
 
 // UpdateLoopResult contains the results of the orderbook update.
+// Note that this is used in `trader/trader.go`, but it is defined here to avoid an import cycle.
 type UpdateLoopResult struct {
 	Success            bool
 	NumPruneOps        int

--- a/plugins/metricsTracker.go
+++ b/plugins/metricsTracker.go
@@ -325,10 +325,10 @@ func (mt *MetricsTracker) SendDeleteEvent(exit bool) error {
 
 // SendEvent sends an event with its type and properties to Amplitude.
 func (mt *MetricsTracker) SendEvent(eventType string, eventPropsInterface interface{}, now time.Time) error {
-	// if mt.apiKey == "" || mt.userID == "-1" || mt.isDisabled {
-	// 	log.Printf("metric - not sending event metric of type '%s' because metrics are disabled", eventType)
-	// 	return nil
-	// }
+	if mt.apiKey == "" || mt.userID == "-1" || mt.isDisabled {
+		log.Printf("metric - not sending event metric of type '%s' because metrics are disabled", eventType)
+		return nil
+	}
 
 	trackerProps := mt.props
 	trackerProps[secondsSinceStartKey] = now.Sub(mt.botStartTime).Seconds()

--- a/trader/trader.go
+++ b/trader/trader.go
@@ -401,6 +401,8 @@ func (t *Trader) update() bool {
 			return false
 		}
 
+		t.metricsTracker.AddPruneOps(len(pruneOps))
+
 		// TODO 2 streamline the request data instead of caching - may not need this since result of PruneOps is async
 		// reset cache of balances for this update cycle to reduce redundant requests to calculate asset balances
 		t.sdex.IEIF().ResetCachedBalances()
@@ -450,6 +452,8 @@ func (t *Trader) update() bool {
 			t.deleteAllOffers(false)
 			return false
 		}
+
+		t.metricsTracker.AddUpdateOpsUpdate(len(ops))
 	}
 
 	e = t.strategy.PostUpdate()

--- a/trader/trader.go
+++ b/trader/trader.go
@@ -453,7 +453,7 @@ func (t *Trader) update() bool {
 			return false
 		}
 
-		t.metricsTracker.AddUpdateOpsUpdate(len(ops))
+		t.metricsTracker.AddUpdatesOpsUpdate(len(ops))
 	}
 
 	e = t.strategy.PostUpdate()

--- a/trader/trader.go
+++ b/trader/trader.go
@@ -470,7 +470,7 @@ func (t *Trader) update() plugins.UpdateLoopResult {
 	}
 
 	msos := api.ConvertTM2MSO(opsOld)
-	numUpdateOpsCreate, numUpdateOpsDelete, numUpdateOpsUpdate, e = countOfferChangeTypes(msos)
+	numUpdateOpsDelete, numUpdateOpsUpdate, numUpdateOpsCreate, e = countOfferChangeTypes(msos)
 	if e != nil {
 		log.Println(e)
 		t.deleteAllOffers(false)
@@ -616,8 +616,8 @@ func (t *Trader) setExistingOffers(sellingAOffers []hProtocol.Offer, buyingAOffe
 	t.sellingAOffers, t.buyingAOffers = sellingAOffers, buyingAOffers
 }
 
-func countOfferChangeTypes(offers []*txnbuild.ManageSellOffer) ( /*numCreate*/ int /*numDelete*/, int /*numUpdate*/, int, error) {
-	numCreate, numDelete, numUpdate := 0, 0, 0
+func countOfferChangeTypes(offers []*txnbuild.ManageSellOffer) (int /*numDelete*/, int /*numUpdate*/, int /*numCreate*/, error) {
+	numDelete, numUpdate, numCreate := 0, 0, 0
 	for i, o := range offers {
 		if o == nil {
 			return 0, 0, 0, fmt.Errorf("offer at index %d was not of expected type ManageSellOffer (actual type = %T): %+v", i, o, o)
@@ -640,5 +640,5 @@ func countOfferChangeTypes(offers []*txnbuild.ManageSellOffer) ( /*numCreate*/ i
 		}
 	}
 
-	return numCreate, numDelete, numUpdate, nil
+	return numDelete, numUpdate, numCreate, nil
 }

--- a/trader/trader.go
+++ b/trader/trader.go
@@ -616,16 +616,16 @@ func (t *Trader) setExistingOffers(sellingAOffers []hProtocol.Offer, buyingAOffe
 	t.sellingAOffers, t.buyingAOffers = sellingAOffers, buyingAOffers
 }
 
-func countOfferChangeTypes(offers []*txnbuild.ManageSellOffer) (int, int, int, error) {
+func countOfferChangeTypes(offers []*txnbuild.ManageSellOffer) ( /*numCreate*/ int /*numDelete*/, int /*numUpdate*/, int, error) {
 	numCreate, numDelete, numUpdate := 0, 0, 0
-	for _, o := range offers {
+	for i, o := range offers {
 		if o == nil {
-			return 0, 0, 0, fmt.Errorf("offers were not of expected type ManageSellOffer")
+			return 0, 0, 0, fmt.Errorf("offer at index %d was not of expected type ManageSellOffer (actual type = %T): %+v", i, o, o)
 		}
 
 		opAmount, e := strconv.ParseFloat(o.Amount, 64)
 		if e != nil {
-			return 0, 0, 0, fmt.Errorf(" invalid operation amount (%s) could not be parsed as float", o.Amount)
+			return 0, 0, 0, fmt.Errorf("invalid operation amount (%s) could not be parsed as float for operation at index %d: %v", o.Amount, i, o)
 		}
 
 		// 0 amount represents deletion

--- a/trader/trader_test.go
+++ b/trader/trader_test.go
@@ -5,11 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stellar/go/txnbuild"
-
 	"github.com/stretchr/testify/assert"
 
 	hProtocol "github.com/stellar/go/protocols/horizon"
+	"github.com/stellar/go/txnbuild"
 	"github.com/stellar/kelp/api"
 	"github.com/stellar/kelp/model"
 )
@@ -311,14 +310,14 @@ func TestCountOfferChangeTypes(t *testing.T) {
 
 	for _, k := range testCases {
 		t.Run(k.name, func(t *testing.T) {
-			gotNumCreate, gotNumDelete, gotNumUpdate, gotErr := countOfferChangeTypes(k.offers)
+			gotNumDelete, gotNumUpdate, gotNumCreate, gotErr := countOfferChangeTypes(k.offers)
 			if !assert.Nil(t, gotErr) {
 				return
 			}
 
-			assert.Equal(t, k.wantNumCreate, gotNumCreate)
 			assert.Equal(t, k.wantNumDelete, gotNumDelete)
 			assert.Equal(t, k.wantNumUpdate, gotNumUpdate)
+			assert.Equal(t, k.wantNumCreate, gotNumCreate)
 		})
 	}
 


### PR DESCRIPTION
This PR adds metrics for operation counts. It's marked as a draft PR because I have a few outstanding questions, and haven't fully tested it until these are resolved.

1. Does this implementation and architecture generally make sense?
2. Am I passing the correct parameters for prune ops and number of update ops in update?
3. Where is the number of update ops in delete supported to be? The only other len(ops) check in `trader/trader.go` is for deletion, but from the data doc, it looks like this count is for the update event, not deletion.