### PR TITLE
Add metrics for trade tracking.

### DIFF
--- a/api/exchange.go
+++ b/api/exchange.go
@@ -237,6 +237,18 @@ type ExchangeShim interface {
 	FillTrackable
 }
 
+// TradeMetricsHandler is invoked by the MetricsTracker to process new trades
+type TradeMetricsHandler interface {
+	HandleTrade(trade model.Trade) error
+	Read(trades []model.Trade)
+	Reset()
+}
+
+// MetricsTracker knows how to track metrics, including trades
+type MetricsTracker interface {
+	RegisterHandler(handler TradeMetricsHandler)
+}
+
 // ConvertOperation2TM is a temporary adapter to support transitioning from the old Go SDK to the new SDK without having to bump the major version
 func ConvertOperation2TM(ops []txnbuild.Operation) []build.TransactionMutator {
 	muts := []build.TransactionMutator{}

--- a/api/exchange.go
+++ b/api/exchange.go
@@ -239,9 +239,10 @@ type ExchangeShim interface {
 
 // TradeMetricsHandler is invoked by the MetricsTracker to process new trades
 type TradeMetricsHandler interface {
-	HandleTrade(trade model.Trade) error
 	Read(trades []model.Trade)
 	Reset()
+	TotalBaseVolume() float64
+	NumTrades() int
 }
 
 // MetricsTracker knows how to track metrics, including trades

--- a/cmd/trade.go
+++ b/cmd/trade.go
@@ -609,6 +609,9 @@ func runTradeCmd(options inputs) {
 		logger.Fatal(l, fmt.Errorf("could not generate metrics tracker: %s", e))
 	}
 
+	tradeMetricsHandler := plugins.MakeTradeMetricsHandler()
+	metricsTracker.RegisterHandler(tradeMetricsHandler)
+
 	e = metricsTracker.SendStartupEvent()
 	if e != nil {
 		logger.Fatal(l, fmt.Errorf("could not send startup event metric: %s", e))

--- a/plugins/tradeMetricsHandler.go
+++ b/plugins/tradeMetricsHandler.go
@@ -22,7 +22,7 @@ func (h *TradeMetricsHandler) Reset() {
 }
 
 // Read stores new trades internally.
-func (h *TradeMetricsHandler) Read(newTrades []model.Trade) error {
+func (h *TradeMetricsHandler) Read(newTrades []model.Trade) {
 	for _, nt := range newTrades {
 		h.trades = append(h.trades, nt)
 	}

--- a/plugins/tradeMetricsHandler.go
+++ b/plugins/tradeMetricsHandler.go
@@ -28,14 +28,15 @@ func (h *TradeMetricsHandler) Read(newTrades []model.Trade) {
 	}
 }
 
-// Get returns the number of trades.
-func (h *TradeMetricsHandler) Get() int {
+// NumTrades returns the number of trades.
+func (h *TradeMetricsHandler) NumTrades() int {
 	return len(h.trades)
 }
 
-// HandleTrade impl
-func (h *TradeMetricsHandler) HandleTrade(trade model.Trade) error {
-	// TODO: Add more if needed.
-	h.trades = append(h.trades, trade)
-	return nil
+// TotalBaseVolume returns the total base volume.
+func (h *TradeMetricsHandler) TotalBaseVolume() (total float64) {
+	for _, t := range h.trades {
+		total += t.Volume.AsFloat()
+	}
+	return
 }

--- a/plugins/tradeMetricsHandler.go
+++ b/plugins/tradeMetricsHandler.go
@@ -1,18 +1,41 @@
-package metrics
+package plugins
 
-// TODO DS Rework handler to accumulate trades, not just count.
-type tradeMetricsHandler struct {
-	numTrades int
+import (
+	"github.com/stellar/kelp/model"
+)
+
+// TradeMetricsHandler tracks the number of trades
+type TradeMetricsHandler struct {
+	trades []model.Trade
 }
 
-func (h *tradeMetricsHandler) Reset() {
-	h.numTrades = 0
+// MakeTradeMetricsHandler is a factory method for the TradeMetricsHandler
+func MakeTradeMetricsHandler() *TradeMetricsHandler {
+	return &TradeMetricsHandler{
+		trades: []model.Trade{},
+	}
 }
 
-func (h *tradeMetricsHandler) Add(numNewTrades int) {
-	h.numTrades += numNewTrades
+// Reset sets the handler's trade counter to zero.
+func (h *TradeMetricsHandler) Reset() {
+	h.trades = []model.Trade{}
 }
 
-func (h *tradeMetricsHandler) Get() int {
-	return h.numTrades
+// Read stores new trades internally.
+func (h *TradeMetricsHandler) Read(newTrades []model.Trade) error {
+	for _, nt := range newTrades {
+		h.trades = append(h.trades, nt)
+	}
+}
+
+// Get returns the number of trades.
+func (h *TradeMetricsHandler) Get() int {
+	return len(h.trades)
+}
+
+// HandleTrade impl
+func (h *TradeMetricsHandler) HandleTrade(trade model.Trade) error {
+	// TODO: Add more if needed.
+	h.trades = append(h.trades, trade)
+	return nil
 }

--- a/plugins/tradeMetricsHandler.go
+++ b/plugins/tradeMetricsHandler.go
@@ -1,0 +1,18 @@
+package metrics
+
+// TODO DS Rework handler to accumulate trades, not just count.
+type tradeMetricsHandler struct {
+	numTrades int
+}
+
+func (h *tradeMetricsHandler) Reset() {
+	h.numTrades = 0
+}
+
+func (h *tradeMetricsHandler) Add(numNewTrades int) {
+	h.numTrades += numNewTrades
+}
+
+func (h *tradeMetricsHandler) Get() int {
+	return h.numTrades
+}

--- a/support/metrics/metricsTracker.go
+++ b/support/metrics/metricsTracker.go
@@ -8,7 +8,8 @@ import (
 	"runtime/debug"
 	"time"
 
-	"github.com/stellar/kelp/plugins"
+	"github.com/stellar/kelp/api"
+	"github.com/stellar/kelp/model"
 	"github.com/stellar/kelp/support/networking"
 )
 
@@ -34,7 +35,7 @@ type MetricsTracker struct {
 	updateEventSentTime *time.Time
 
 	// uninitialized
-	handlers []plugins.TradeMetricsHandler
+	handlers []api.TradeMetricsHandler
 }
 
 // TODO DS Investigate other fields to add to this top-level event.
@@ -310,6 +311,39 @@ func (mt *MetricsTracker) sendEvent(eventType string, eventProps interface{}) er
 }
 
 // RegisterHandler adds an internal handler.
-func (mt *MetricsTracker) RegisterHandler(handler plugins.TradeMetricsHandler) {
+func (mt *MetricsTracker) RegisterHandler(handler api.TradeMetricsHandler) {
 	mt.handlers = append(mt.handlers, handler)
+}
+
+// GetHandlers returns the handlers
+func (mt *MetricsTracker) GetHandlers() []api.TradeMetricsHandler {
+	return mt.handlers
+}
+
+// ResetHandlers resets all handlers
+func (mt *MetricsTracker) ResetHandlers() {
+	for _, h := range mt.handlers {
+		h.Reset()
+	}
+}
+
+// ReadIntoHandlers reads to all handlers
+func (mt *MetricsTracker) ReadIntoHandlers(trades []model.Trade) {
+	for _, h := range mt.handlers {
+		h.Read(trades)
+	}
+}
+
+func (mt *MetricsTracker) getTotalVolume() (total float64) {
+	for _, h := range mt.handlers {
+		total += h.TotalBaseVolume()
+	}
+	return
+}
+
+func (mt *MetricsTracker) getTotalNumTrades() (total int) {
+	for _, h := range mt.handlers {
+		total += h.NumTrades()
+	}
+	return
 }

--- a/support/metrics/metricsTracker.go
+++ b/support/metrics/metricsTracker.go
@@ -8,6 +8,7 @@ import (
 	"runtime/debug"
 	"time"
 
+	"github.com/stellar/kelp/plugins"
 	"github.com/stellar/kelp/support/networking"
 )
 
@@ -31,6 +32,9 @@ type MetricsTracker struct {
 	botStartTime        time.Time
 	isDisabled          bool
 	updateEventSentTime *time.Time
+
+	// uninitialized
+	handlers []plugins.TradeMetricsHandler
 }
 
 // TODO DS Investigate other fields to add to this top-level event.
@@ -303,4 +307,9 @@ func (mt *MetricsTracker) sendEvent(eventType string, eventProps interface{}) er
 		}
 	}
 	return nil
+}
+
+// RegisterHandler adds an internal handler.
+func (mt *MetricsTracker) RegisterHandler(handler plugins.TradeMetricsHandler) {
+	mt.handlers = append(mt.handlers, handler)
 }

--- a/trader/trader.go
+++ b/trader/trader.go
@@ -311,6 +311,8 @@ func (t *Trader) synchronizeFetchBalancesOffersTrades() error {
 			buyingAOffers2,
 		) {
 			// this is the only success case
+			t.metricsTracker.ResetHandlers()
+			t.metricsTracker.ReadIntoHandlers(trades)
 			t.setBalances(baseBalance1, quoteBalance1)
 			t.setExistingOffers(sellingAOffers1, buyingAOffers1)
 			return nil


### PR DESCRIPTION
This PR adds metrics to track trades. Thus far, it adds a handler interface and implementation. The metrics will be actually added after #508 is merged, because the architecture around adding individual metrics changes.