### PR TITLE
Clean up root binary invocation (closes #568)

### DIFF
--- a/cmd/server_amd64.go
+++ b/cmd/server_amd64.go
@@ -78,7 +78,7 @@ func init() {
 	options.horizonPubnetURI = serverCmd.Flags().String("horizon-pubnet-uri", "https://horizon.stellar.org", "URI to use for the horizon instance connected to the Stellar Public Network (must not contain the word 'test')")
 	options.noHeaders = serverCmd.Flags().Bool("no-headers", false, "do not use Amplitude or set X-App-Name and X-App-Version headers on requests to horizon")
 	options.verbose = serverCmd.Flags().BoolP("verbose", "v", false, "enable verbose log lines typically used for debugging")
-	options.noElectron = serverCmd.Flags().Bool("no-electron", false, "open in browser instead of using electron")
+	options.noElectron = serverCmd.Flags().Bool("no-electron", true, "open in browser instead of using electron")
 
 	serverCmd.Run = func(ccmd *cobra.Command, args []string) {
 		isLocalMode := env == envDev

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -409,10 +409,6 @@ do
         env GOOS=$GOOS GOARCH=$GOARCH GOARM=$GOARM go build -ldflags "$LDFLAGS" -o $ARCHIVE_DIR_SOURCE_UI/$GOOS-$GOARCH/kelp.exe
         check_build_result $?
         echo "successful"
-        
-        echo -n "copying over kelp-start.bat file to the windows build ..."
-        cp $KELP/gui/windows-bat-file/kelp-start.bat $ARCHIVE_DIR_SOURCE_UI/$GOOS-$GOARCH/
-        echo "done"
 
         # set paths needed for unzipping the vendor and ccxt files
         VENDOR_FILENAME=""


### PR DESCRIPTION
This PR cleans up the root binary invocation logic, and closes #568. 