### PR TITLE
Modify tests for volume filter

### DIFF
--- a/plugins/volumeFilter_test.go
+++ b/plugins/volumeFilter_test.go
@@ -168,6 +168,19 @@ func TestVolumeFilterFn(t *testing.T) {
 		wantTbbBase    *float64
 		wantTbbQuote   *float64
 	}{
+		// These are all the paths that can happen, assuming exactly one quote exists (a check before this function).
+		//
+		// no quote cap; base cap, projected sold < cap -> keep selling base w/ same amount
+		// no quote cap; base cap, projected sold = cap -> keep selling base w/ same amount
+		// no quote cap; base cap, projected sold > cap, not exact -> don't keep selling base
+		// no quote cap; base cap, projected sold > cap, exact, no capacity -> don't keep selling base
+		// no quote cap; base cap, projected sold > cap, exact, yes capacity -> keep selling base w/ updated amount
+
+		// no base cap; quote cap, projected sold < cap -> keep selling quote w/ same amount
+		// no base cap; quote cap, projected sold = cap -> keep selling quote w/ same amount
+		// no base cap; quote cap, projected sold > cap, not exact -> don't keep selling quote
+		// no base cap; quote cap, projected sold > cap, exact, no capacity -> don't keep selling quote
+		// no base cap; quote cap, projected sold > cap, exact, yes capacity -> keep selling quote w/ updated amount
 		{
 			name:           "1. selling, base units sell cap, don't keep selling base, exact mode",
 			mode:           volumeFilterModeExact,

--- a/plugins/volumeFilter_test.go
+++ b/plugins/volumeFilter_test.go
@@ -348,7 +348,22 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 	}
 }
 
-func runTestVolumeFilterFn(t *testing.T, name string, mode volumeFilterMode, action queries.DailyVolumeAction, baseCap *float64, quoteCap *float64, baseOTB *float64, quoteOTB *float64, baseTBB *float64, quoteTBB *float64, inputOp *txnbuild.ManageSellOffer, wantOp *txnbuild.ManageSellOffer, wantBase *float64, wantQuote *float64) {
+func runTestVolumeFilterFn(
+	t *testing.T,
+	name string,
+	mode volumeFilterMode,
+	action queries.DailyVolumeAction,
+	baseCap *float64,
+	quoteCap *float64,
+	baseOTB *float64,
+	quoteOTB *float64,
+	baseTBB *float64,
+	quoteTBB *float64,
+	inputOp *txnbuild.ManageSellOffer,
+	wantOp *txnbuild.ManageSellOffer,
+	wantBase *float64,
+	wantQuote *float64,
+) {
 	t.Run(name, func(t *testing.T) {
 		// exactly one of the two cap values must be set
 		if baseCap == nil && quoteCap == nil {
@@ -374,7 +389,9 @@ func runTestVolumeFilterFn(t *testing.T, name string, mode volumeFilterMode, act
 		if !assert.Nil(t, e) {
 			return
 		}
-		assert.Equal(t, wantOp, actual)
+		if !assert.Equal(t, wantOp, actual) {
+			return
+		}
 
 		wantTBBAccumulator := makeRawVolumeFilterConfig(wantBase, wantQuote, action, mode, nil, nil)
 		assert.Equal(t, wantTBBAccumulator, dailyTBBAccumulator)

--- a/plugins/volumeFilter_test.go
+++ b/plugins/volumeFilter_test.go
@@ -159,7 +159,8 @@ type volumeFilterFnTestCase struct {
 	otb          float64
 	tbbBase      float64
 	tbbQuote     float64
-	inputOp      *txnbuild.ManageSellOffer
+	inputPrice   float64
+	inputAmount  float64
 	wantOp       *txnbuild.ManageSellOffer
 	wantTbbBase  float64
 	wantTbbQuote float64
@@ -179,7 +180,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			otb:          0,
 			tbbBase:      5,
 			tbbQuote:     0,
-			inputOp:      makeSellOp(2.0, 4.99),
+			inputPrice:   2.0,
+			inputAmount:  4.99,
 			wantOp:       makeSellOp(2.0, 4.99),
 			wantTbbBase:  9.99,
 			wantTbbQuote: 9.98,
@@ -190,7 +192,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			otb:          0,
 			tbbBase:      5,
 			tbbQuote:     0,
-			inputOp:      makeSellOp(2.0, 5),
+			inputPrice:   2.0,
+			inputAmount:  5.0,
 			wantOp:       makeSellOp(2.0, 5),
 			wantTbbBase:  10,
 			wantTbbQuote: 10,
@@ -201,6 +204,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			otb:          0,
 			tbbBase:      5,
 			tbbQuote:     0,
+			inputPrice:   2.0,
+			inputAmount:  5.01,
 			inputOp:      makeSellOp(2.0, 5.01),
 			wantOp:       nil,
 			wantTbbBase:  5,
@@ -212,7 +217,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			otb:          5,
 			tbbBase:      0,
 			tbbQuote:     0,
-			inputOp:      makeSellOp(2.0, 4.99),
+			inputPrice:   2.0,
+			inputAmount:  4.99,
 			wantOp:       makeSellOp(2.0, 4.99),
 			wantTbbBase:  4.99,
 			wantTbbQuote: 9.98,
@@ -223,7 +229,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			otb:          5,
 			tbbBase:      0,
 			tbbQuote:     0,
-			inputOp:      makeSellOp(2.0, 5.0),
+			inputPrice:   2.0,
+			inputAmount:  5.0,
 			wantOp:       makeSellOp(2.0, 5.0),
 			wantTbbBase:  5,
 			wantTbbQuote: 10,
@@ -234,7 +241,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			otb:          5,
 			tbbBase:      0,
 			tbbQuote:     0,
-			inputOp:      makeSellOp(2.0, 6.0),
+			inputPrice:   2.0,
+			inputAmount:  6.0,
 			wantOp:       nil,
 			wantTbbBase:  0,
 			wantTbbQuote: 0,
@@ -245,7 +253,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			otb:          0,
 			tbbBase:      0,
 			tbbQuote:     0,
-			inputOp:      makeSellOp(2.0, 5.0),
+			inputPrice:   2.0,
+			inputAmount:  5.0,
 			wantOp:       makeSellOp(2.0, 5.0),
 			wantTbbBase:  5,
 			wantTbbQuote: 10,
@@ -256,7 +265,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			otb:          0,
 			tbbBase:      0,
 			tbbQuote:     0,
-			inputOp:      makeSellOp(2.0, 10.0),
+			inputPrice:   2.0,
+			inputAmount:  10.0,
 			wantOp:       makeSellOp(2.0, 10.0),
 			wantTbbBase:  10,
 			wantTbbQuote: 20,
@@ -267,7 +277,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			otb:          0,
 			tbbBase:      0,
 			tbbQuote:     0,
-			inputOp:      makeSellOp(2.0, 15.0),
+			inputPrice:   2.0,
+			inputAmount:  15.0,
 			wantOp:       nil,
 			wantTbbBase:  0,
 			wantTbbQuote: 0,
@@ -278,7 +289,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			otb:          1,
 			tbbBase:      1,
 			tbbQuote:     0,
-			inputOp:      makeSellOp(2.0, 5.0),
+			inputPrice:   2.0,
+			inputAmount:  5.0,
 			wantOp:       makeSellOp(2.0, 5.0),
 			wantTbbBase:  6,
 			wantTbbQuote: 10,
@@ -289,7 +301,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			otb:          2,
 			tbbBase:      2,
 			tbbQuote:     0,
-			inputOp:      makeSellOp(2.0, 6.0),
+			inputPrice:   2.0,
+			inputAmount:  6.0,
 			wantOp:       makeSellOp(2.0, 6.0),
 			wantTbbBase:  8,
 			wantTbbQuote: 12,
@@ -300,7 +313,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			otb:          2,
 			tbbBase:      2,
 			tbbQuote:     0,
-			inputOp:      makeSellOp(2.0, 7.0),
+			inputPrice:   2.0,
+			inputAmount:  7.0,
 			wantOp:       nil,
 			wantTbbBase:  2,
 			wantTbbQuote: 0,
@@ -309,6 +323,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 	for _, k := range testCases {
 		// convert to common format accepted by runTestVolumeFilterFn
 		// doing this explicitly here is easier to read rather than if we were to add "logic" to convert it to a standard format
+		inputOp := makeSellOp(k.inputPrice, k.inputAmount)
 		runTestVolumeFilterFn(
 			t,
 			k.name,
@@ -320,7 +335,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			nil,                        // quoteOTB nil because this test is for the BaseCap
 			pointy.Float64(k.tbbBase),  // baseTBB
 			pointy.Float64(k.tbbQuote), // quoteTBB (non-nil since it accumulates)
-			k.inputOp,
+			inputOp,
 			k.wantOp,
 			pointy.Float64(k.wantTbbBase),
 			pointy.Float64(k.wantTbbQuote),

--- a/plugins/volumeFilter_test.go
+++ b/plugins/volumeFilter_test.go
@@ -168,19 +168,6 @@ func TestVolumeFilterFn(t *testing.T) {
 		wantTbbBase    *float64
 		wantTbbQuote   *float64
 	}{
-		// These are all the paths that can happen, assuming exactly one quote exists (a check before this function).
-		//
-		// no quote cap; base cap, projected sold < cap -> keep selling base w/ same amount
-		// no quote cap; base cap, projected sold = cap -> keep selling base w/ same amount
-		// no quote cap; base cap, projected sold > cap, not exact -> don't keep selling base
-		// no quote cap; base cap, projected sold > cap, exact, no capacity -> don't keep selling base
-		// no quote cap; base cap, projected sold > cap, exact, yes capacity -> keep selling base w/ updated amount
-
-		// no base cap; quote cap, projected sold < cap -> keep selling quote w/ same amount
-		// no base cap; quote cap, projected sold = cap -> keep selling quote w/ same amount
-		// no base cap; quote cap, projected sold > cap, not exact -> don't keep selling quote
-		// no base cap; quote cap, projected sold > cap, exact, no capacity -> don't keep selling quote
-		// no base cap; quote cap, projected sold > cap, exact, yes capacity -> keep selling quote w/ updated amount
 		{
 			name:           "1. selling, base units sell cap, don't keep selling base, exact mode",
 			mode:           volumeFilterModeExact,

--- a/plugins/volumeFilter_test.go
+++ b/plugins/volumeFilter_test.go
@@ -176,7 +176,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 	// 12 cases here; 4 combinations of tbb/otb values from bullet points above x 3 combinations of cap relationship to projected (<, =, >)
 	testCases := []volumeFilterFnTestCase{
 		{
-			name:         "1. otb = 0; cap > projected",
+			name:         "1. otb = 0; projected < cap",
 			cap:          10.0,
 			otb:          0,
 			tbbBase:      5,
@@ -189,7 +189,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbQuote: 9.98,
 		},
 		{
-			name:         "2. otb = 0; cap = projected",
+			name:         "2. otb = 0; projected = cap",
 			cap:          10.0,
 			otb:          0,
 			tbbBase:      5,
@@ -202,7 +202,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbQuote: 10,
 		},
 		{
-			name:         "3. otb = 0; cap < projected",
+			name:         "3. otb = 0; projected > cap",
 			cap:          10.0,
 			otb:          0,
 			tbbBase:      5,
@@ -215,7 +215,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbQuote: 0,
 		},
 		{
-			name:         "4. tbb = 0; cap > projected",
+			name:         "4. tbb = 0; projected < cap",
 			cap:          10.0,
 			otb:          5,
 			tbbBase:      0,
@@ -228,7 +228,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbQuote: 9.98,
 		},
 		{
-			name:         "5. tbb = 0; cap = projected",
+			name:         "5. tbb = 0; projected = cap",
 			cap:          10.0,
 			otb:          5,
 			tbbBase:      0,
@@ -241,7 +241,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbQuote: 10,
 		},
 		{
-			name:         "6. tbb = 0; cap < projected",
+			name:         "6. tbb = 0; projected > cap",
 			cap:          10.0,
 			otb:          5,
 			tbbBase:      0,
@@ -254,7 +254,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbQuote: 0,
 		},
 		{
-			name:         "7. otb = 0 && tbb = 0; cap > projected",
+			name:         "7. otb = 0 && tbb = 0; projected < cap",
 			cap:          10.0,
 			otb:          0,
 			tbbBase:      0,
@@ -267,7 +267,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbQuote: 10,
 		},
 		{
-			name:         "8. otb = 0 && tbb = 0; cap = projected",
+			name:         "8. otb = 0 && tbb = 0; projected = cap",
 			cap:          10.0,
 			otb:          0,
 			tbbBase:      0,
@@ -280,7 +280,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbQuote: 20,
 		},
 		{
-			name:         "9. otb = 0 && tbb = 0; cap < projected",
+			name:         "9. otb = 0 && tbb = 0; projected > cap",
 			cap:          10.0,
 			otb:          0,
 			tbbBase:      0,
@@ -293,7 +293,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbQuote: 0,
 		},
 		{
-			name:         "10. otb > 0 && tbb > 0; cap > projected",
+			name:         "10. otb > 0 && tbb > 0; projected < cap",
 			cap:          10.0,
 			otb:          1,
 			tbbBase:      1,
@@ -306,7 +306,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbQuote: 10,
 		},
 		{
-			name:         "11. otb > 0 && tbb > 0; cap = projected",
+			name:         "11. otb > 0 && tbb > 0; projected = cap",
 			cap:          10.0,
 			otb:          2,
 			tbbBase:      2,
@@ -319,7 +319,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbQuote: 12,
 		},
 		{
-			name:         "12. otb > 0 && tbb > 0; cap < projected",
+			name:         "12. otb > 0 && tbb > 0; projected > cap",
 			cap:          10.0,
 			otb:          2,
 			tbbBase:      2,
@@ -335,11 +335,11 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 	for _, k := range testCases {
 		// convert to common format accepted by runTestVolumeFilterFn
 		// doing this explicitly here is easier to read rather than if we were to add "logic" to convert it to a standard format
-		inputOp := makeSellOp(k.inputPrice, k.inputAmount)
+		inputOp := makeSellOpAmtPrice(k.inputAmount, k.inputPrice)
 
 		var wantOp *txnbuild.ManageSellOffer
 		if k.wantPrice != nil && k.wantAmount != nil {
-			wantOp = makeSellOp(*k.wantPrice, *k.wantAmount)
+			wantOp = makeSellOpAmtPrice(*k.wantAmount, *k.wantPrice)
 		}
 
 		runTestVolumeFilterFn(
@@ -571,12 +571,12 @@ func makeManageSellOffer(price string, amount string) *txnbuild.ManageSellOffer 
 	}
 }
 
-func makeSellOp(price float64, amount float64) *txnbuild.ManageSellOffer {
+func makeSellOpAmtPrice(amount float64, price float64) *txnbuild.ManageSellOffer {
 	return &txnbuild.ManageSellOffer{
 		Buying:  txnbuild.NativeAsset{},
 		Selling: txnbuild.NativeAsset{},
-		Price:   fmt.Sprintf("%.7f", price),
 		Amount:  fmt.Sprintf("%.7f", amount),
+		Price:   fmt.Sprintf("%.7f", price),
 	}
 }
 

--- a/plugins/volumeFilter_test.go
+++ b/plugins/volumeFilter_test.go
@@ -161,7 +161,8 @@ type volumeFilterFnTestCase struct {
 	tbbQuote     float64
 	inputPrice   float64
 	inputAmount  float64
-	wantOp       *txnbuild.ManageSellOffer
+	wantPrice    *float64
+	wantAmount   *float64
 	wantTbbBase  float64
 	wantTbbQuote float64
 }
@@ -182,7 +183,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			tbbQuote:     0,
 			inputPrice:   2.0,
 			inputAmount:  4.99,
-			wantOp:       makeSellOp(2.0, 4.99),
+			wantPrice:    pointy.Float64(2.0),
+			wantAmount:   pointy.Float64(4.99),
 			wantTbbBase:  9.99,
 			wantTbbQuote: 9.98,
 		},
@@ -194,7 +196,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			tbbQuote:     0,
 			inputPrice:   2.0,
 			inputAmount:  5.0,
-			wantOp:       makeSellOp(2.0, 5),
+			wantPrice:    pointy.Float64(2.0),
+			wantAmount:   pointy.Float64(5),
 			wantTbbBase:  10,
 			wantTbbQuote: 10,
 		},
@@ -206,8 +209,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			tbbQuote:     0,
 			inputPrice:   2.0,
 			inputAmount:  5.01,
-			inputOp:      makeSellOp(2.0, 5.01),
-			wantOp:       nil,
+			wantPrice:    nil,
+			wantAmount:   nil,
 			wantTbbBase:  5,
 			wantTbbQuote: 0,
 		},
@@ -219,7 +222,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			tbbQuote:     0,
 			inputPrice:   2.0,
 			inputAmount:  4.99,
-			wantOp:       makeSellOp(2.0, 4.99),
+			wantPrice:    pointy.Float64(2.0),
+			wantAmount:   pointy.Float64(4.99),
 			wantTbbBase:  4.99,
 			wantTbbQuote: 9.98,
 		},
@@ -231,7 +235,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			tbbQuote:     0,
 			inputPrice:   2.0,
 			inputAmount:  5.0,
-			wantOp:       makeSellOp(2.0, 5.0),
+			wantPrice:    pointy.Float64(2.0),
+			wantAmount:   pointy.Float64(5.0),
 			wantTbbBase:  5,
 			wantTbbQuote: 10,
 		},
@@ -243,7 +248,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			tbbQuote:     0,
 			inputPrice:   2.0,
 			inputAmount:  6.0,
-			wantOp:       nil,
+			wantPrice:    nil,
+			wantAmount:   nil,
 			wantTbbBase:  0,
 			wantTbbQuote: 0,
 		},
@@ -255,7 +261,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			tbbQuote:     0,
 			inputPrice:   2.0,
 			inputAmount:  5.0,
-			wantOp:       makeSellOp(2.0, 5.0),
+			wantPrice:    pointy.Float64(2.0),
+			wantAmount:   pointy.Float64(5.0),
 			wantTbbBase:  5,
 			wantTbbQuote: 10,
 		},
@@ -267,7 +274,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			tbbQuote:     0,
 			inputPrice:   2.0,
 			inputAmount:  10.0,
-			wantOp:       makeSellOp(2.0, 10.0),
+			wantPrice:    pointy.Float64(2.0),
+			wantAmount:   pointy.Float64(10.0),
 			wantTbbBase:  10,
 			wantTbbQuote: 20,
 		},
@@ -279,7 +287,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			tbbQuote:     0,
 			inputPrice:   2.0,
 			inputAmount:  15.0,
-			wantOp:       nil,
+			wantPrice:    nil,
+			wantAmount:   nil,
 			wantTbbBase:  0,
 			wantTbbQuote: 0,
 		},
@@ -291,7 +300,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			tbbQuote:     0,
 			inputPrice:   2.0,
 			inputAmount:  5.0,
-			wantOp:       makeSellOp(2.0, 5.0),
+			wantPrice:    pointy.Float64(2.0),
+			wantAmount:   pointy.Float64(5.0),
 			wantTbbBase:  6,
 			wantTbbQuote: 10,
 		},
@@ -303,7 +313,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			tbbQuote:     0,
 			inputPrice:   2.0,
 			inputAmount:  6.0,
-			wantOp:       makeSellOp(2.0, 6.0),
+			wantPrice:    pointy.Float64(2.0),
+			wantAmount:   pointy.Float64(6.0),
 			wantTbbBase:  8,
 			wantTbbQuote: 12,
 		},
@@ -315,7 +326,8 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			tbbQuote:     0,
 			inputPrice:   2.0,
 			inputAmount:  7.0,
-			wantOp:       nil,
+			wantPrice:    nil,
+			wantAmount:   nil,
 			wantTbbBase:  2,
 			wantTbbQuote: 0,
 		},
@@ -324,6 +336,12 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 		// convert to common format accepted by runTestVolumeFilterFn
 		// doing this explicitly here is easier to read rather than if we were to add "logic" to convert it to a standard format
 		inputOp := makeSellOp(k.inputPrice, k.inputAmount)
+
+		var wantOp *txnbuild.ManageSellOffer
+		if k.wantPrice != nil && k.wantAmount != nil {
+			wantOp = makeSellOp(*k.wantPrice, *k.wantAmount)
+		}
+
 		runTestVolumeFilterFn(
 			t,
 			k.name,
@@ -336,7 +354,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			pointy.Float64(k.tbbBase),  // baseTBB
 			pointy.Float64(k.tbbQuote), // quoteTBB (non-nil since it accumulates)
 			inputOp,
-			k.wantOp,
+			wantOp,
 			pointy.Float64(k.wantTbbBase),
 			pointy.Float64(k.wantTbbQuote),
 		)

--- a/plugins/volumeFilter_test.go
+++ b/plugins/volumeFilter_test.go
@@ -157,8 +157,7 @@ type volumeFilterFnTestCase struct {
 	name         string
 	cap          float64
 	otb          float64
-	tbbBase      float64
-	tbbQuote     float64
+	tbb          float64
 	inputPrice   float64
 	inputAmount  float64
 	wantPrice    *float64
@@ -179,8 +178,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			name:         "1. otb = 0; projected < cap",
 			cap:          10.0,
 			otb:          0,
-			tbbBase:      5,
-			tbbQuote:     0,
+			tbb:          5,
 			inputPrice:   2.0,
 			inputAmount:  4.99,
 			wantPrice:    pointy.Float64(2.0),
@@ -192,8 +190,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			name:         "2. otb = 0; projected = cap",
 			cap:          10.0,
 			otb:          0,
-			tbbBase:      5,
-			tbbQuote:     0,
+			tbb:          5,
 			inputPrice:   2.0,
 			inputAmount:  5.0,
 			wantPrice:    pointy.Float64(2.0),
@@ -205,8 +202,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			name:         "3. otb = 0; projected > cap",
 			cap:          10.0,
 			otb:          0,
-			tbbBase:      5,
-			tbbQuote:     0,
+			tbb:          5,
 			inputPrice:   2.0,
 			inputAmount:  5.01,
 			wantPrice:    nil,
@@ -218,8 +214,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			name:         "4. tbb = 0; projected < cap",
 			cap:          10.0,
 			otb:          5,
-			tbbBase:      0,
-			tbbQuote:     0,
+			tbb:          0,
 			inputPrice:   2.0,
 			inputAmount:  4.99,
 			wantPrice:    pointy.Float64(2.0),
@@ -231,8 +226,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			name:         "5. tbb = 0; projected = cap",
 			cap:          10.0,
 			otb:          5,
-			tbbBase:      0,
-			tbbQuote:     0,
+			tbb:          0,
 			inputPrice:   2.0,
 			inputAmount:  5.0,
 			wantPrice:    pointy.Float64(2.0),
@@ -244,8 +238,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			name:         "6. tbb = 0; projected > cap",
 			cap:          10.0,
 			otb:          5,
-			tbbBase:      0,
-			tbbQuote:     0,
+			tbb:          0,
 			inputPrice:   2.0,
 			inputAmount:  6.0,
 			wantPrice:    nil,
@@ -257,8 +250,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			name:         "7. otb = 0 && tbb = 0; projected < cap",
 			cap:          10.0,
 			otb:          0,
-			tbbBase:      0,
-			tbbQuote:     0,
+			tbb:          0,
 			inputPrice:   2.0,
 			inputAmount:  5.0,
 			wantPrice:    pointy.Float64(2.0),
@@ -270,8 +262,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			name:         "8. otb = 0 && tbb = 0; projected = cap",
 			cap:          10.0,
 			otb:          0,
-			tbbBase:      0,
-			tbbQuote:     0,
+			tbb:          0,
 			inputPrice:   2.0,
 			inputAmount:  10.0,
 			wantPrice:    pointy.Float64(2.0),
@@ -283,8 +274,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			name:         "9. otb = 0 && tbb = 0; projected > cap",
 			cap:          10.0,
 			otb:          0,
-			tbbBase:      0,
-			tbbQuote:     0,
+			tbb:          0,
 			inputPrice:   2.0,
 			inputAmount:  15.0,
 			wantPrice:    nil,
@@ -296,8 +286,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			name:         "10. otb > 0 && tbb > 0; projected < cap",
 			cap:          10.0,
 			otb:          1,
-			tbbBase:      1,
-			tbbQuote:     0,
+			tbb:          1,
 			inputPrice:   2.0,
 			inputAmount:  5.0,
 			wantPrice:    pointy.Float64(2.0),
@@ -309,8 +298,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			name:         "11. otb > 0 && tbb > 0; projected = cap",
 			cap:          10.0,
 			otb:          2,
-			tbbBase:      2,
-			tbbQuote:     0,
+			tbb:          2,
 			inputPrice:   2.0,
 			inputAmount:  6.0,
 			wantPrice:    pointy.Float64(2.0),
@@ -322,8 +310,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			name:         "12. otb > 0 && tbb > 0; projected > cap",
 			cap:          10.0,
 			otb:          2,
-			tbbBase:      2,
-			tbbQuote:     0,
+			tbb:          2,
 			inputPrice:   2.0,
 			inputAmount:  7.0,
 			wantPrice:    nil,
@@ -347,12 +334,12 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			k.name,
 			volumeFilterModeIgnore,
 			queries.DailyVolumeActionSell,
-			pointy.Float64(k.cap),      // base cap
-			nil,                        // quote cap nil because this test is for the BaseCap
-			pointy.Float64(k.otb),      // baseOTB
-			nil,                        // quoteOTB nil because this test is for the BaseCap
-			pointy.Float64(k.tbbBase),  // baseTBB
-			pointy.Float64(k.tbbQuote), // quoteTBB (non-nil since it accumulates)
+			pointy.Float64(k.cap), // base cap
+			nil,                   // quote cap nil because this test is for the BaseCap
+			pointy.Float64(k.otb), // baseOTB
+			nil,                   // quoteOTB nil because this test is for the BaseCap
+			pointy.Float64(k.tbb), // baseTBB
+			pointy.Float64(0),     // quoteTBB (non-nil since it accumulates)
 			inputOp,
 			wantOp,
 			pointy.Float64(k.wantTbbBase),

--- a/plugins/volumeFilter_test.go
+++ b/plugins/volumeFilter_test.go
@@ -173,7 +173,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 	// otb > 0 && tbb > 0
 	// 12 cases here; 4 combinations of tbb/otb values from bullet points above x 3 combinations of cap relationship to projected (<, =, >)
 	testCases := []volumeFilterFnTestCase{
-		volumeFilterFnTestCase{
+		{
 			name:         "1. otb = 0; cap > projected",
 			cap:          10.0,
 			otb:          0,
@@ -184,7 +184,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbBase:  9.99,
 			wantTbbQuote: 9.98,
 		},
-		volumeFilterFnTestCase{
+		{
 			name:         "2. otb = 0; cap = projected",
 			cap:          10.0,
 			otb:          0,
@@ -195,7 +195,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbBase:  10,
 			wantTbbQuote: 10,
 		},
-		volumeFilterFnTestCase{
+		{
 			name:         "3. otb = 0; cap < projected",
 			cap:          10.0,
 			otb:          0,
@@ -206,7 +206,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbBase:  5,
 			wantTbbQuote: 0,
 		},
-		volumeFilterFnTestCase{
+		{
 			name:         "4. tbb = 0; cap > projected",
 			cap:          10.0,
 			otb:          5,
@@ -217,7 +217,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbBase:  4.99,
 			wantTbbQuote: 9.98,
 		},
-		volumeFilterFnTestCase{
+		{
 			name:         "5. tbb = 0; cap = projected",
 			cap:          10.0,
 			otb:          5,
@@ -228,7 +228,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbBase:  5,
 			wantTbbQuote: 10,
 		},
-		volumeFilterFnTestCase{
+		{
 			name:         "6. tbb = 0; cap < projected",
 			cap:          10.0,
 			otb:          5,
@@ -239,7 +239,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbBase:  0,
 			wantTbbQuote: 0,
 		},
-		volumeFilterFnTestCase{
+		{
 			name:         "7. otb = 0 && tbb = 0; cap > projected",
 			cap:          10.0,
 			otb:          0,
@@ -250,7 +250,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbBase:  5,
 			wantTbbQuote: 10,
 		},
-		volumeFilterFnTestCase{
+		{
 			name:         "8. otb = 0 && tbb = 0; cap = projected",
 			cap:          10.0,
 			otb:          0,
@@ -261,7 +261,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbBase:  10,
 			wantTbbQuote: 20,
 		},
-		volumeFilterFnTestCase{
+		{
 			name:         "9. otb = 0 && tbb = 0; cap < projected",
 			cap:          10.0,
 			otb:          0,
@@ -272,7 +272,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbBase:  0,
 			wantTbbQuote: 0,
 		},
-		volumeFilterFnTestCase{
+		{
 			name:         "10. otb > 0 && tbb > 0; cap > projected",
 			cap:          10.0,
 			otb:          1,
@@ -283,7 +283,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbBase:  6,
 			wantTbbQuote: 10,
 		},
-		volumeFilterFnTestCase{
+		{
 			name:         "11. otb > 0 && tbb > 0; cap = projected",
 			cap:          10.0,
 			otb:          2,
@@ -294,7 +294,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbBase:  8,
 			wantTbbQuote: 12,
 		},
-		volumeFilterFnTestCase{
+		{
 			name:         "12. otb > 0 && tbb > 0; cap < projected",
 			cap:          10.0,
 			otb:          2,

--- a/plugins/volumeFilter_test.go
+++ b/plugins/volumeFilter_test.go
@@ -185,7 +185,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbQuote: 9.98,
 		},
 		volumeFilterFnTestCase{
-			name:         "2. otb = 0; cap > projected",
+			name:         "2. otb = 0; cap = projected",
 			cap:          10.0,
 			otb:          0,
 			tbbBase:      5,
@@ -196,7 +196,7 @@ func TestVolumeFilterFn_BaseCap_Ignore(t *testing.T) {
 			wantTbbQuote: 10,
 		},
 		volumeFilterFnTestCase{
-			name:         "3. otb = 0; cap > projected",
+			name:         "3. otb = 0; cap < projected",
 			cap:          10.0,
 			otb:          0,
 			tbbBase:      5,
@@ -538,14 +538,13 @@ func makeManageSellOffer(price string, amount string) *txnbuild.ManageSellOffer 
 	}
 }
 
-
 func makeSellOp(price float64, amount float64) *txnbuild.ManageSellOffer {
 	return &txnbuild.ManageSellOffer{
 		Buying:  txnbuild.NativeAsset{},
 		Selling: txnbuild.NativeAsset{},
 		Price:   fmt.Sprintf("%.7f", price),
 		Amount:  fmt.Sprintf("%.7f", amount),
-  }
+	}
 }
 
 func TestValidateConfig(t *testing.T) {


### PR DESCRIPTION
This PR modifies tests for the volume filter. Now, we test each combination of mode and action differently. Within a given mode/action combination, we test the four relationships of OTB and TBB values times the three ways the projected amount sold relates to the cap - giving us twelve possible cases.

Once this PR is merged, we'll add similar sets of twelve cases for the other mode/action combinations. (Note that these cases will not be identical, as changing the mode or action would result in different outputs.) This comprehensive approach allows us to safely regression test as we implement buy TWAP.