### PR TITLE
Test buy-side for volume filter with base cap and exact mode

### DIFF
--- a/plugins/volumeFilter.go
+++ b/plugins/volumeFilter.go
@@ -191,16 +191,24 @@ func volumeFilterFn(dailyOTB *VolumeFilterConfig, dailyTBBAccumulator *VolumeFil
 		return nil, fmt.Errorf("could not convert price (%s) to float: %s", op.Price, e)
 	}
 
+	offerAmount, e := strconv.ParseFloat(op.Amount, 64)
+	if e != nil {
+		return nil, fmt.Errorf("could not convert amount (%s) to float: %s", op.Amount, e)
+	}
+
+	// A "buy" op has amount = sellAmount * sellPrice, and price = 1/sellPrice
+	// So, we adjust the offer variables by "undoing" those adjustments
+	// We can then use the same computations as sell orders on buy orders
+	if dailyOTB.action.IsBuy() {
+		offerAmount = offerAmount * offerPrice
+		offerPrice = 1 / offerPrice
+	}
+
 	// capPrice is used when computing amounts to sell or buy
 	// it's the offer price when capping on quote, and 1.0 when capping on base
 	capPrice := offerPrice
 	if lp.baseAssetCapInBaseUnits != nil {
 		capPrice = 1.0
-	}
-
-	offerAmount, e := strconv.ParseFloat(op.Amount, 64)
-	if e != nil {
-		return nil, fmt.Errorf("could not convert amount (%s) to float: %s", op.Amount, e)
 	}
 
 	// extracts from base or quote side, depending on filter
@@ -228,8 +236,15 @@ func volumeFilterFn(dailyOTB *VolumeFilterConfig, dailyTBBAccumulator *VolumeFil
 		return nil, nil
 	}
 
-	op.Amount = fmt.Sprintf("%.7f", newOfferAmount)
 	dailyTBBAccumulator = updateTBB(dailyTBBAccumulator, newOfferAmount, offerPrice)
+
+	// if we have a buy operation, we want to make sure buy ops have the same relationship between price and amount
+	// to do this, we apply the same amount adjustment as `makeBuyOpAmtPrice`
+	newOpAmount := newOfferAmount
+	if dailyOTB.action.IsBuy() {
+		newOpAmount = newOpAmount * offerPrice
+	}
+	op.Amount = fmt.Sprintf("%.7f", newOpAmount)
 	return op, nil
 }
 

--- a/plugins/volumeFilter.go
+++ b/plugins/volumeFilter.go
@@ -240,6 +240,13 @@ func volumeFilterFn(dailyOTB *VolumeFilterConfig, dailyTBBAccumulator *VolumeFil
 
 	// if we have a buy operation, we want to make sure buy ops have the same relationship between price and amount
 	// to do this, we apply the same amount adjustment as `makeBuyOpAmtPrice`
+	// The following conversion is done above on input:
+	// sellOfferAmount = buyOfferAmount * buyOfferPrice
+	// sellOfferPrice = 1 / buyOfferPrice
+	//
+	// Therefore we need to undo it using the following:
+	// newOpAmount = newOpAmount * sellOfferPrice
+	// newOpAmount => newOpAmount * 1 / buyOfferPrice
 	newOpAmount := newOfferAmount
 	if dailyOTB.action.IsBuy() {
 		newOpAmount = newOpAmount * offerPrice

--- a/plugins/volumeFilter_test.go
+++ b/plugins/volumeFilter_test.go
@@ -1115,14 +1115,10 @@ func runTestVolumeFilterFn(
 			mode:                     mode,
 		}
 
-		// if we are testing sell, we make the base and quote assets both native (XLM)
-		// if we are testing buy, we make the base the COUPON asset
-		baseAsset := utils.NativeAsset
+		// if we are testing sell, both the base and quote assets are native (XLM)
+		// but if we are testing buy, the base is the COUPON asset
+		baseAsset := utils.Asset2Asset2(inputOp.Buying)
 		quoteAsset := utils.NativeAsset
-		if dailyOTB.action.IsBuy() {
-			baseAsset = utils.Asset2Asset2(buyOpAsset)
-		}
-
 		actual, e := volumeFilterFn(dailyOTB, dailyTBBAccumulator, inputOp, baseAsset, quoteAsset, lp)
 		if !assert.Nil(t, e) {
 			return

--- a/plugins/volumeFilter_test.go
+++ b/plugins/volumeFilter_test.go
@@ -166,7 +166,7 @@ type volumeFilterFnTestCase struct {
 	wantTbbQuote float64
 }
 
-func TestVolumeFilterFn_BaseCap_Exact(t *testing.T) {
+func TestVolumeFilterFn_Sell_BaseCap_Exact(t *testing.T) {
 	// We want to test the following 4 valid combinations of OTB and TBB values:
 	// otb = 0
 	// tbb = 0

--- a/plugins/volumeFilter_test.go
+++ b/plugins/volumeFilter_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var buyOpAsset txnbuild.CreditAsset = txnbuild.CreditAsset{Code: "COUPON", Issuer: "GBMMZMK2DC4FFP4CAI6KCVNCQ7WLO5A7DQU7EC7WGHRDQBZB763X4OQI"}
-
 func makeWantVolumeFilter(config *VolumeFilterConfig, marketIDs []string, accountIDs []string, action queries.DailyVolumeAction) *volumeFilter {
 	query, e := queries.MakeDailyVolumeByDateForMarketIdsAction(&sql.DB{}, marketIDs, action, accountIDs)
 	if e != nil {
@@ -415,7 +413,7 @@ func TestVolumeFilterFn_BaseCap_Exact(t *testing.T) {
 	for _, k := range testCases {
 		for _, action := range actions {
 			// convert to common format accepted by runTestVolumeFilterFn
-			// since we use the same test cases for both actions,
+			// since we use the same test cases for both actions, we construct the appropriate op for the action
 			inputOp := makeActionOpAmtPrice(action, k.inputAmount, k.inputPrice)
 			var wantOp *txnbuild.ManageSellOffer
 			if k.wantPrice != nil && k.wantAmount != nil {
@@ -1147,6 +1145,8 @@ func makeSellOpAmtPrice(amount float64, price float64) *txnbuild.ManageSellOffer
 		Price:   fmt.Sprintf("%.7f", price),
 	}
 }
+
+var buyOpAsset txnbuild.CreditAsset = txnbuild.CreditAsset{Code: "COUPON", Issuer: "GBMMZMK2DC4FFP4CAI6KCVNCQ7WLO5A7DQU7EC7WGHRDQBZB763X4OQI"}
 
 func makeBuyOpAmtPrice(amount float64, price float64) *txnbuild.ManageSellOffer {
 	// the test buy ops are a ManageSellOffer with the COUPON asset as buying and XLM as selling

--- a/plugins/volumeFilter_test.go
+++ b/plugins/volumeFilter_test.go
@@ -1167,11 +1167,20 @@ func makeSellOpAmtPrice(amount float64, price float64) *txnbuild.ManageSellOffer
 func makeBuyOpAmtPrice(amount float64, price float64) *txnbuild.ManageSellOffer {
 	// in Kelp, all actions are performed in context of the base asset
 	// a sell op sells base, and a buy op buys base/sells quote
+	// I ran this using the buysell strategy with the amount set to 1000.0 units (of base on either side), with the buy op being displayed first:
+	// 2020/12/23 02:35:59 submitting the following ops
+	// 2020/12/23 02:35:59 &{Selling:{Code:COUPON Issuer:GBMMZMK2DC4FFP4CAI6KCVNCQ7WLO5A7DQU7EC7WGHRDQBZB763X4OQI} Buying:{} Amount:163.4735274 Price:6.1171984 OfferID:0 SourceAccount:0xc00047e5e0}
+	// 2020/12/23 02:35:59 &{Selling:{} Buying:{Code:COUPON Issuer:GBMMZMK2DC4FFP4CAI6KCVNCQ7WLO5A7DQU7EC7WGHRDQBZB763X4OQI} Amount:1000.0000000 Price:0.1638006 OfferID:0 SourceAccount:0xc00047e6a0}
+	// above, we can see that the selling operation (second op) has amount = 1000.0 and price = 0.16 which is correct
+	// the buying op (first op) has amount set to 163.xx and price set to 6.xx, and we need to replicate this.
+	// To do so, we need to:
+	// set our Amount field on the manageSellOffer here equal to amount * price (so we get 1000 * 0.16 ~= 163.xx like displayed above)
+	// set the Price field to 1/price (so we get 1/0.16 ~= 6.xx like displayed above)
 	return &txnbuild.ManageSellOffer{
 		Buying:  testBaseAsset,
 		Selling: testQuoteAsset,
-		Amount:  fmt.Sprintf("%.7f", amount),
-		Price:   fmt.Sprintf("%.7f", price),
+		Amount:  fmt.Sprintf("%.7f", amount*price),
+		Price:   fmt.Sprintf("%.7f", 1/price),
 	}
 }
 

--- a/plugins/volumeFilter_test.go
+++ b/plugins/volumeFilter_test.go
@@ -168,7 +168,7 @@ type volumeFilterFnTestCase struct {
 	wantTbbQuote float64
 }
 
-func TestVolumeFilterFn_Buy_BaseCap_Exact(t *testing.T) {
+func TestVolumeFilterFn_BaseCap_Exact(t *testing.T) {
 	// We want to test the following 4 valid combinations of OTB and TBB values:
 	// otb = 0
 	// tbb = 0
@@ -411,304 +411,34 @@ func TestVolumeFilterFn_Buy_BaseCap_Exact(t *testing.T) {
 			wantTbbQuote: 0,
 		},
 	}
+	actions := []queries.DailyVolumeAction{queries.DailyVolumeActionSell, queries.DailyVolumeActionBuy}
 	for _, k := range testCases {
-		// convert to common format accepted by runTestVolumeFilterFn
-		// doing this explicitly here is easier to read rather than if we were to add "logic" to convert it to a standard format
-		inputOp := makeBuyOpAmtPrice(k.inputAmount, k.inputPrice)
+		for _, action := range actions {
+			// convert to common format accepted by runTestVolumeFilterFn
+			// since we use the same test cases for both actions,
+			inputOp := makeActionOpAmtPrice(action, k.inputAmount, k.inputPrice)
+			var wantOp *txnbuild.ManageSellOffer
+			if k.wantPrice != nil && k.wantAmount != nil {
+				wantOp = makeActionOpAmtPrice(action, *k.wantAmount, *k.wantPrice)
+			}
 
-		var wantOp *txnbuild.ManageSellOffer
-		if k.wantPrice != nil && k.wantAmount != nil {
-			wantOp = makeBuyOpAmtPrice(*k.wantAmount, *k.wantPrice)
+			runTestVolumeFilterFn(
+				t,
+				k.name,
+				volumeFilterModeExact,
+				action,
+				pointy.Float64(k.cap), // base cap
+				nil,                   // quote cap nil because this test is for the BaseCap
+				pointy.Float64(k.otb), // baseOTB
+				nil,                   // quoteOTB nil because this test is for the BaseCap
+				pointy.Float64(k.tbb), // baseTBB
+				pointy.Float64(0),     // quoteTBB (non-nil since it accumulates)
+				inputOp,
+				wantOp,
+				pointy.Float64(k.wantTbbBase),
+				pointy.Float64(k.wantTbbQuote),
+			)
 		}
-
-		runTestVolumeFilterFn(
-			t,
-			k.name,
-			volumeFilterModeExact,
-			queries.DailyVolumeActionBuy,
-			pointy.Float64(k.cap), // base cap
-			nil,                   // quote cap nil because this test is for the BaseCap
-			pointy.Float64(k.otb), // baseOTB
-			nil,                   // quoteOTB nil because this test is for the BaseCap
-			pointy.Float64(k.tbb), // baseTBB
-			pointy.Float64(0),     // quoteTBB (non-nil since it accumulates)
-			inputOp,
-			wantOp,
-			pointy.Float64(k.wantTbbBase),
-			pointy.Float64(k.wantTbbQuote),
-		)
-	}
-}
-
-func TestVolumeFilterFn_Sell_BaseCap_Exact(t *testing.T) {
-	// We want to test the following 4 valid combinations of OTB and TBB values:
-	// otb = 0
-	// tbb = 0
-	// otb = 0 && tbb = 0
-	// otb > 0 && tbb > 0
-	// We also want to test 3 combinations of cap relationship to projected (<, =, >)
-	// Finally, if projected > cap, we want to test 3 possible values of newAmount (+, 0, -)
-	// The above gives 4 * (2 + 1*3) = 20.
-	// One generated case is impossible in the code: otb = 0 && tbb = 0, newAmount < 0
-	// so we have 19 cases
-	testCases := []volumeFilterFnTestCase{
-		{
-			name:         "1. otb = 0; projected < cap",
-			cap:          10.0,
-			otb:          0,
-			tbb:          5,
-			inputPrice:   2.0,
-			inputAmount:  4.99,
-			wantPrice:    pointy.Float64(2.0),
-			wantAmount:   pointy.Float64(4.99),
-			wantTbbBase:  9.99,
-			wantTbbQuote: 9.98,
-		},
-		{
-			name:         "2. otb = 0; projected = cap",
-			cap:          10.0,
-			otb:          0,
-			tbb:          5,
-			inputPrice:   2.0,
-			inputAmount:  5.0,
-			wantPrice:    pointy.Float64(2.0),
-			wantAmount:   pointy.Float64(5),
-			wantTbbBase:  10,
-			wantTbbQuote: 10,
-		},
-		{
-			name:         "3. otb = 0; projected > cap, newAmount > 0",
-			cap:          10.0,
-			otb:          0,
-			tbb:          5,
-			inputPrice:   2.0,
-			inputAmount:  5.01,
-			wantPrice:    pointy.Float64(2.0),
-			wantAmount:   pointy.Float64(5.0),
-			wantTbbBase:  10,
-			wantTbbQuote: 10,
-		},
-		{
-			name:         "4. otb = 0; projected > cap, newAmount = 0",
-			cap:          10.0,
-			otb:          0,
-			tbb:          10,
-			inputPrice:   2.0,
-			inputAmount:  5.01,
-			wantPrice:    nil,
-			wantAmount:   nil,
-			wantTbbBase:  10,
-			wantTbbQuote: 0,
-		},
-		{
-			name:         "5. otb = 0; projected > cap, newAmount < 0",
-			cap:          10.0,
-			otb:          0,
-			tbb:          11,
-			inputPrice:   2.0,
-			inputAmount:  5.01,
-			wantPrice:    nil,
-			wantAmount:   nil,
-			wantTbbBase:  11,
-			wantTbbQuote: 0,
-		},
-		{
-			name:         "6. tbb = 0; projected < cap",
-			cap:          10.0,
-			otb:          5,
-			tbb:          0,
-			inputPrice:   2.0,
-			inputAmount:  4.99,
-			wantPrice:    pointy.Float64(2.0),
-			wantAmount:   pointy.Float64(4.99),
-			wantTbbBase:  4.99,
-			wantTbbQuote: 9.98,
-		},
-		{
-			name:         "7. tbb = 0; projected = cap",
-			cap:          10.0,
-			otb:          5,
-			tbb:          0,
-			inputPrice:   2.0,
-			inputAmount:  5.0,
-			wantPrice:    pointy.Float64(2.0),
-			wantAmount:   pointy.Float64(5.0),
-			wantTbbBase:  5,
-			wantTbbQuote: 10,
-		},
-		{
-			name:         "8. tbb = 0; projected > cap, newAmount > 0",
-			cap:          10.0,
-			otb:          5,
-			tbb:          0,
-			inputPrice:   2.0,
-			inputAmount:  6.0,
-			wantPrice:    pointy.Float64(2.0),
-			wantAmount:   pointy.Float64(5.0),
-			wantTbbBase:  5,
-			wantTbbQuote: 10,
-		},
-		{
-			name:         "9. tbb = 0; projected > cap, newAmount = 0",
-			cap:          10.0,
-			otb:          10,
-			tbb:          0,
-			inputPrice:   2.0,
-			inputAmount:  6.0,
-			wantPrice:    nil,
-			wantAmount:   nil,
-			wantTbbBase:  0,
-			wantTbbQuote: 0,
-		},
-		{
-			name:         "10. tbb = 0; projected > cap, newAmount < 0",
-			cap:          10.0,
-			otb:          11,
-			tbb:          0,
-			inputPrice:   2.0,
-			inputAmount:  6.0,
-			wantPrice:    nil,
-			wantAmount:   nil,
-			wantTbbBase:  0,
-			wantTbbQuote: 0,
-		},
-		{
-			name:         "11. otb = 0 && tbb = 0; projected < cap",
-			cap:          10.0,
-			otb:          0,
-			tbb:          0,
-			inputPrice:   2.0,
-			inputAmount:  5.0,
-			wantPrice:    pointy.Float64(2.0),
-			wantAmount:   pointy.Float64(5.0),
-			wantTbbBase:  5,
-			wantTbbQuote: 10,
-		},
-		{
-			name:         "12. otb = 0 && tbb = 0; projected = cap",
-			cap:          10.0,
-			otb:          0,
-			tbb:          0,
-			inputPrice:   2.0,
-			inputAmount:  10.0,
-			wantPrice:    pointy.Float64(2.0),
-			wantAmount:   pointy.Float64(10.0),
-			wantTbbBase:  10,
-			wantTbbQuote: 20,
-		},
-		{
-			// note that in this case, newAmount >= 0, since newAmount = cap - otb - tbb
-			name:         "13. otb = 0 && tbb = 0; projected > cap, newAmount > 0",
-			cap:          10.0,
-			otb:          0,
-			tbb:          0,
-			inputPrice:   2.0,
-			inputAmount:  15.0,
-			wantPrice:    pointy.Float64(2.0),
-			wantAmount:   pointy.Float64(10.0),
-			wantTbbBase:  10,
-			wantTbbQuote: 20,
-		},
-		{
-			name:         "14. otb = 0 && tbb = 0; projected > cap, newAmount = 0",
-			cap:          0.0,
-			otb:          0,
-			tbb:          0,
-			inputPrice:   2.0,
-			inputAmount:  15.0,
-			wantPrice:    nil,
-			wantAmount:   nil,
-			wantTbbBase:  0,
-			wantTbbQuote: 0,
-		},
-		// it is not possible for otb = 0 && tbb = 0 and newAmount < 0, so skipping that case
-		{
-			name:         "15. otb > 0 && tbb > 0; projected < cap",
-			cap:          10.0,
-			otb:          1,
-			tbb:          1,
-			inputPrice:   2.0,
-			inputAmount:  5.0,
-			wantPrice:    pointy.Float64(2.0),
-			wantAmount:   pointy.Float64(5.0),
-			wantTbbBase:  6,
-			wantTbbQuote: 10,
-		},
-		{
-			name:         "16. otb > 0 && tbb > 0; projected = cap",
-			cap:          10.0,
-			otb:          2,
-			tbb:          2,
-			inputPrice:   2.0,
-			inputAmount:  6.0,
-			wantPrice:    pointy.Float64(2.0),
-			wantAmount:   pointy.Float64(6.0),
-			wantTbbBase:  8,
-			wantTbbQuote: 12,
-		},
-		{
-			name:         "17. otb > 0 && tbb > 0; projected > cap, newAmount > 0",
-			cap:          10.0,
-			otb:          2,
-			tbb:          2,
-			inputPrice:   2.0,
-			inputAmount:  7.0,
-			wantPrice:    pointy.Float64(2.0),
-			wantAmount:   pointy.Float64(6.0),
-			wantTbbBase:  8,
-			wantTbbQuote: 12,
-		},
-		{
-			name:         "18. otb > 0 && tbb > 0; projected > cap, newAmount = 0",
-			cap:          10.0,
-			otb:          5,
-			tbb:          5,
-			inputPrice:   2.0,
-			inputAmount:  7.0,
-			wantPrice:    nil,
-			wantAmount:   nil,
-			wantTbbBase:  5,
-			wantTbbQuote: 0,
-		},
-		{
-			name:         "19. otb > 0 && tbb > 0; projected > cap, newAmount < 0",
-			cap:          10.0,
-			otb:          5,
-			tbb:          5.1,
-			inputPrice:   2.0,
-			inputAmount:  7.0,
-			wantPrice:    nil,
-			wantAmount:   nil,
-			wantTbbBase:  5.1,
-			wantTbbQuote: 0,
-		},
-	}
-	for _, k := range testCases {
-		// convert to common format accepted by runTestVolumeFilterFn
-		// doing this explicitly here is easier to read rather than if we were to add "logic" to convert it to a standard format
-		inputOp := makeSellOpAmtPrice(k.inputAmount, k.inputPrice)
-
-		var wantOp *txnbuild.ManageSellOffer
-		if k.wantPrice != nil && k.wantAmount != nil {
-			wantOp = makeSellOpAmtPrice(*k.wantAmount, *k.wantPrice)
-		}
-
-		runTestVolumeFilterFn(
-			t,
-			k.name,
-			volumeFilterModeExact,
-			queries.DailyVolumeActionSell,
-			pointy.Float64(k.cap), // base cap
-			nil,                   // quote cap nil because this test is for the BaseCap
-			pointy.Float64(k.otb), // baseOTB
-			nil,                   // quoteOTB nil because this test is for the BaseCap
-			pointy.Float64(k.tbb), // baseTBB
-			pointy.Float64(0),     // quoteTBB (non-nil since it accumulates)
-			inputOp,
-			wantOp,
-			pointy.Float64(k.wantTbbBase),
-			pointy.Float64(k.wantTbbQuote),
-		)
 	}
 }
 
@@ -1404,6 +1134,13 @@ func runTestVolumeFilterFn(
 		wantTBBAccumulator := makeRawVolumeFilterConfig(wantBase, wantQuote, action, mode, nil, nil)
 		assert.Equal(t, wantTBBAccumulator, dailyTBBAccumulator)
 	})
+}
+
+func makeActionOpAmtPrice(action queries.DailyVolumeAction, amount float64, price float64) *txnbuild.ManageSellOffer {
+	if action.IsSell() {
+		return makeSellOpAmtPrice(amount, price)
+	}
+	return makeBuyOpAmtPrice(amount, price)
 }
 
 func makeSellOpAmtPrice(amount float64, price float64) *txnbuild.ManageSellOffer {


### PR DESCRIPTION
This PR integrates tests for the buy-side for the volume filter, with the base cap and exact mode. Since we are keeping the test cases the same as the sell-side, this PR extends the existing function to also test base. It creates a buy operation with a different base asset; changes the asset used in `runTestVolumeFilterFn`; and loops over both actions in the test function.

To make the existing test cases all work, this also tweaks the `makeBuyOpSellAmt` and the logic around computing buy offers.