### PR TITLE
Make local development and running simpler

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,6 +62,8 @@ var RootCmd = &cobra.Command{
 			if e != nil {
 				panic(e)
 			}
+		} else {
+			panic(fmt.Sprintf("unrecognized buildType: %s", buildType))
 		}
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,14 +56,12 @@ var RootCmd = &cobra.Command{
 		if buildType == "gui" {
 			// if this is the GUI binary then we want to start off with the server command
 			serverCmd.Run(ccmd, args)
-		} else if buildType == "cli" {
+		} else if buildType == "cli" || buildType == "" {
 			// else start off with the help command
 			e := ccmd.Help()
 			if e != nil {
 				panic(e)
 			}
-		} else {
-			panic(fmt.Sprintf("unrecognized buildType: %s", buildType))
 		}
 	},
 }
@@ -108,12 +106,16 @@ func checkInitRootFlags() {
 }
 
 func validateBuild() {
+	if env != envRelease {
+		return
+	}
+
 	if version == "" || guiVersion == "" || buildDate == "" || gitBranch == "" || gitHash == "" {
 		fmt.Println("version information not included, please build using the build script (scripts/build.sh)")
 		os.Exit(1)
 	}
 
-	if amplitudeAPIKey == "" && env == envRelease {
+	if amplitudeAPIKey == "" {
 		utils.PrintErrorHintf("amplitude API key not included, please export AMPLITUDE_API_KEY before running build script (scripts/build.sh)")
 		os.Exit(1)
 	}


### PR DESCRIPTION
### What
Don't require build information when running locally during development.

### Why
When developing locally it is useful to be able to run kelp as is with simple commands like `go run .`. That isn't possible today because kelp requires a variety of build parameters to be specified. That's inconvenient for local development, and it is only really necessary to have all these build parameters included when releasing.